### PR TITLE
FOSDEM 2019 talk example slides for graphs via org-mode and python

### DIFF
--- a/conference/FOSDEM2019/slides_examples.org
+++ b/conference/FOSDEM2019/slides_examples.org
@@ -27,11 +27,11 @@ Examples in section "Plotting with python"
 | legend       | rx_drop | nanosec per packet |  saved ns |
 |--------------+---------+--------------------+-----------|
 | baseline     |    15.1 |          66.225166 |        0. |
-| XDP_ATTACH   |    17.1 |          58.479532 |  7.745634 |
-| RM-indirect  |    23.4 |          42.735043 | 23.490123 |
+| ATTACH       |    17.1 |          58.479532 |  7.745634 |
+| 1-indirect   |    23.4 |          42.735043 | 23.490123 |
 | RM-switch    |    31.5 |          31.746032 | 34.479134 |
 | various      |    36.8 |          27.173913 | 39.051253 |
-| explicit-ctx |    39.3 |          25.445293 | 40.779873 |
+| ctx          |    39.3 |          25.445293 | 40.779873 |
 #+TBLFM: $3=(1/$2)*(1000)::$4=(@2$3)-$3
 
 * Example-1: Python pyplot code                                    :noexport:
@@ -41,24 +41,67 @@ Execute python code in emacs via keyboard shortcut: =C-c C-c=
 #+BEGIN_SRC python :var fname="rx_drop.png" :var data=data01 :results file
 import matplotlib.pyplot as plt
 
-txt, y, z, a = zip(*data)
+txt, rx_drop, c, d = zip(*data)
 
 fig = plt.figure()
-axes = fig.add_subplot(1,1,1)
-axes.plot(txt, y, marker='o')
-fig.savefig(fname)
+axes = fig.add_subplot(1,1, 1)
+axes.plot(txt, rx_drop, marker='o')
 
+plt.title('AF_XDP - RX-drop')
+fig.savefig(fname)
 return fname
 #+END_SRC
 
 #+RESULTS:
 [[file:rx_drop.png]]
 
-* Example-1 slide                                                    :export:
+* Slide: Example-1                                                   :export:
 
 file:rx_drop.png
 
 Not much room for describing the figure
+
+
+* Example-2: Python pyplot code                                    :noexport:
+
+Execute python code in emacs via keyboard shortcut: =C-c C-c=
+
+#+BEGIN_SRC python :var fname="bar_chart.png" :var data=data01 :results file
+import matplotlib.pyplot as plt
+
+txt, y, z, a = zip(*data)
+
+fig = plt.figure()
+axes = fig.add_subplot(1,1,1)
+axes.plot(txt, y, marker='o')
+
+import matplotlib.pyplot as plt; plt.rcdefaults()
+import numpy as np
+import matplotlib.pyplot as plt
+
+objects = [a[0] for a in data]
+y_pos = np.arange(len(objects))
+performance = [a[1] for a in data]
+
+plt.bar(y_pos, performance, align='center', alpha=0.6)
+plt.xticks(y_pos, objects)
+plt.ylabel('Mpps')
+plt.title('AF_XDP - RX-drop')
+
+fig.savefig(fname)
+return fname
+#+END_SRC
+
+#+RESULTS:
+[[file:bar_chart.png]]
+
+
+* Slide: Example-2: Bar Chart                                        :export:
+
+file:bar_chart.png
+
+Not much room for describing the figure
+
 
 * Emacs tricks
 

--- a/conference/FOSDEM2019/slides_examples.org
+++ b/conference/FOSDEM2019/slides_examples.org
@@ -66,7 +66,7 @@ file:rx_drop.png
 
 Not much room for describing the figure
 
-* Example-2: Python pyplot code                                    :noexport:
+* Example-2: Python code for bar chart                             :noexport:
 
 Execute python code in emacs via keyboard shortcut: =C-c C-c=
 
@@ -80,12 +80,21 @@ performance = [a[1] for a in data]
 
 my_colors = ['xkcd:blue', 'xkcd:orange', 'xkcd:green', 'xkcd:red',
              'xkcd:purple', 'xkcd:brown' ]
-plt.bar(y_pos, performance, align='center', alpha=0.6, color=my_colors)
-plt.xticks(y_pos, objects)
-plt.ylabel('Mpps')
-plt.title('AF_XDP - RX-drop')
 
-plt.savefig(fname)
+fig, ax = plt.subplots()
+ax.set_ylabel('Mpps')
+ax.set_title('AF_XDP - RX-drop')
+
+rects = ax.bar(y_pos, performance, align='center', alpha=0.6, color=my_colors)
+ax.set_xticks(y_pos)
+ax.set_xticklabels(objects)
+
+for rect in rects:
+    height = rect.get_height()
+    ax.text(rect.get_x() + rect.get_width()/2., height,
+            height, ha='center', va='bottom')
+
+fig.savefig(fname)
 return fname
 #+END_SRC
 
@@ -136,6 +145,8 @@ return fname
 file:bar_chart_horizontal.svg
 
 # No room for info on slide any-longer
+
+
 
 
 * Emacs tricks

--- a/conference/FOSDEM2019/slides_examples.org
+++ b/conference/FOSDEM2019/slides_examples.org
@@ -71,17 +71,8 @@ Not much room for describing the figure
 Execute python code in emacs via keyboard shortcut: =C-c C-c=
 
 #+BEGIN_SRC python :var fname="bar_chart.png" :var data=data01 :results file
-import matplotlib.pyplot as plt
-
-txt, y, z, a = zip(*data)
-
-fig = plt.figure()
-axes = fig.add_subplot(1,1,1)
-axes.plot(txt, y, marker='o')
-
 import matplotlib.pyplot as plt; plt.rcdefaults()
 import numpy as np
-import matplotlib.pyplot as plt
 
 objects = [a[0] for a in data]
 y_pos = np.arange(len(objects))
@@ -92,7 +83,7 @@ plt.xticks(y_pos, objects)
 plt.ylabel('Mpps')
 plt.title('AF_XDP - RX-drop')
 
-fig.savefig(fname)
+plt.savefig(fname)
 return fname
 #+END_SRC
 

--- a/conference/FOSDEM2019/slides_examples.org
+++ b/conference/FOSDEM2019/slides_examples.org
@@ -70,7 +70,7 @@ Not much room for describing the figure
 
 Execute python code in emacs via keyboard shortcut: =C-c C-c=
 
-#+BEGIN_SRC python :var fname="bar_chart.png" :var data=data01 :results file
+#+BEGIN_SRC python :var fname="bar_chart.svg" :var data=data01 :results file
 import matplotlib.pyplot as plt; plt.rcdefaults()
 import numpy as np
 
@@ -90,15 +90,14 @@ return fname
 #+END_SRC
 
 #+RESULTS:
-[[file:bar_chart.png]]
+[[file:bar_chart.svg]]
 
 
 * Slide: Example-2: Bar Chart                                        :export:
 
-file:bar_chart.png
+file:bar_chart.svg
 
-Not much room for describing the figure
-
+# No room for describing the figure when using SVG
 
 
 * Example-3: Python code for horizontal bar chart                  :noexport:

--- a/conference/FOSDEM2019/slides_examples.org
+++ b/conference/FOSDEM2019/slides_examples.org
@@ -27,15 +27,16 @@ Different types of bar-chart's:
 * Example-1: Data                                                    :export:
 
 #+tblname: data01
-| legend     | rx_drop | nanosec per packet | saved ns |
-|------------+---------+--------------------+----------|
-| baseline   |    15.1 |              66.23 |       0. |
-| ATTACH     |    17.1 |              58.48 |     7.75 |
-| 1-indirect |    23.4 |              42.74 |    23.49 |
-| RM-switch  |    31.5 |              31.75 |    34.48 |
-| various    |    36.8 |              27.17 |    39.06 |
-| ctx        |    39.3 |              25.45 |    40.78 |
-#+TBLFM: $3=(1/$2)*(1000);%.2f::$4=(@2$3)-$3
+| legend          | rx_drop | nanosec per packet | saved ns | improve ns since prev |
+|-----------------+---------+--------------------+----------+-----------------------|
+| baseline        |    15.1 |              66.23 |       0. |                     0 |
+| XDP_ATTACH      |    17.1 |              58.48 |     7.75 |                  7.75 |
+| remove-indirect |    23.4 |              42.74 |    23.49 |                 15.74 |
+| no-case-switch  |    31.5 |              31.75 |    34.48 |                 10.99 |
+| various         |    36.8 |              27.17 |    39.06 |                  4.58 |
+| explicit-ctx    |    39.3 |              25.45 |    40.78 |                  1.72 |
+#+TBLFM: $3=(1/$2)*(1000);%.2f::$4=(@2$3)-$3::$5=@-1$3-$3::@2$5=0
+
 
 Tables can also be exported in a slide
 
@@ -48,7 +49,7 @@ import matplotlib.pyplot as plt
 import matplotlib as mpl
 mpl.rcParams['figure.figsize'] = [8.0+4.9, 4.5]
 
-txt, rx_drop, c, d = zip(*data)
+txt, rx_drop, c, d, e = zip(*data)
 
 plt.xkcd()
 fig = plt.figure()
@@ -153,9 +154,7 @@ return fname
 
 file:bar_chart_horizontal.svg
 
-# No room for info on slide any-longer
-
-
+Bar Chart Horizontal for RX-drop with AF_XDP
 
 
 * Emacs tricks

--- a/conference/FOSDEM2019/slides_examples.org
+++ b/conference/FOSDEM2019/slides_examples.org
@@ -43,11 +43,14 @@ Tables can also be exported in a slide
 
 Execute python code in emacs via keyboard shortcut: =C-c C-c=
 
-#+BEGIN_SRC python :var fname="rx_drop.png" :var data=data01 :results file
+#+BEGIN_SRC python :var fname="example-1.svg" :var data=data01 :results file
 import matplotlib.pyplot as plt
+import matplotlib as mpl
+mpl.rcParams['figure.figsize'] = [8.0+4.9, 4.5]
 
 txt, rx_drop, c, d = zip(*data)
 
+plt.xkcd()
 fig = plt.figure()
 axes = fig.add_subplot(1,1, 1)
 axes.plot(txt, rx_drop, marker='o')
@@ -58,21 +61,25 @@ return fname
 #+END_SRC
 
 #+RESULTS:
-[[file:rx_drop.png]]
+[[file:example-1.svg]]
 
 * Slide: Example-1                                                   :export:
 
-file:rx_drop.png
+file:example-1.svg
 
 Not much room for describing the figure
+
 
 * Example-2: Python code for bar chart                             :noexport:
 
 Execute python code in emacs via keyboard shortcut: =C-c C-c=
 
 #+BEGIN_SRC python :var fname="bar_chart.svg" :var data=data01 :results file
-import matplotlib.pyplot as plt; plt.rcdefaults()
+import matplotlib.pyplot as plt
+import matplotlib as mpl
 import numpy as np
+'''PDF render resolution 1600 x 900 => 8 x 4.5'''
+mpl.rcParams['figure.figsize'] = [8.0+5, 4.5]
 
 objects = [a[0] for a in data]
 y_pos = np.arange(len(objects))
@@ -106,7 +113,7 @@ return fname
 
 file:bar_chart.svg
 
-# No room for describing the figure when using SVG
+Bar chart for AF_XDP RX-drop without touching data
 
 
 * Example-3: Python code for horizontal bar chart                  :noexport:
@@ -118,7 +125,9 @@ Execute python code in emacs via keyboard shortcut: =C-c C-c=
 
 #+BEGIN_SRC python :var fname="bar_chart_horizontal.svg" :var data=data01 :results file
 import matplotlib.pyplot as plt; plt.rcdefaults()
+import matplotlib as mpl
 import numpy as np
+mpl.rcParams['figure.figsize'] = [8.0+5, 4.5]
 
 objects = [a[0] for a in data]
 y_pos = np.arange(len(objects))

--- a/conference/FOSDEM2019/slides_examples.org
+++ b/conference/FOSDEM2019/slides_examples.org
@@ -21,6 +21,9 @@ Found online resources:
 Examples in section "Plotting with python"
 - http://ehneilsen.net/notebook/orgExamples/org-examples.html
 
+Different types of bar-chart's:
+- https://pythonspot.com/matplotlib-bar-chart/
+
 * Example-1: Data                                                    :export:
 
 #+tblname: data01
@@ -63,7 +66,6 @@ file:rx_drop.png
 
 Not much room for describing the figure
 
-
 * Example-2: Python pyplot code                                    :noexport:
 
 Execute python code in emacs via keyboard shortcut: =C-c C-c=
@@ -103,6 +105,41 @@ return fname
 file:bar_chart.png
 
 Not much room for describing the figure
+
+
+
+* Example-3: Python code for horizontal bar chart                  :noexport:
+
+Matplotlib charts can create horizontal bar charts.
+ - Inspired by: https://pythonspot.com/matplotlib-bar-chart/
+
+Execute python code in emacs via keyboard shortcut: =C-c C-c=
+
+#+BEGIN_SRC python :var fname="bar_chart_horizontal.svg" :var data=data01 :results file
+import matplotlib.pyplot as plt; plt.rcdefaults()
+import numpy as np
+
+objects = [a[0] for a in data]
+y_pos = np.arange(len(objects))
+performance = [a[1] for a in data]
+
+plt.barh(y_pos, performance, align='center', alpha=0.6)
+plt.yticks(y_pos, objects)
+plt.xlabel('Mpps')
+plt.title('AF_XDP - RX-drop')
+
+plt.savefig(fname)
+return fname
+#+END_SRC
+
+#+RESULTS:
+[[file:bar_chart_horizontal.svg]]
+
+* Slide: Example-3: Bar Chart Horizontal                             :export:
+
+file:bar_chart_horizontal.svg
+
+# No room for info on slide any-longer
 
 
 * Emacs tricks

--- a/conference/FOSDEM2019/slides_examples.org
+++ b/conference/FOSDEM2019/slides_examples.org
@@ -24,17 +24,17 @@ Examples in section "Plotting with python"
 Different types of bar-chart's:
 - https://pythonspot.com/matplotlib-bar-chart/
 
-* Example-1: Data                                                    :export:
+* Data01 for Example-1 + 2 + 3                                       :export:
 
 #+tblname: data01
-| legend          | rx_drop | nanosec per packet | saved ns | improve ns since prev |
-|-----------------+---------+--------------------+----------+-----------------------|
-| baseline        |    15.1 |              66.23 |       0. |                     0 |
-| XDP_ATTACH      |    17.1 |              58.48 |     7.75 |                  7.75 |
-| remove-indirect |    23.4 |              42.74 |    23.49 |                 15.74 |
-| no-case-switch  |    31.5 |              31.75 |    34.48 |                 10.99 |
-| various         |    36.8 |              27.17 |    39.06 |                  4.58 |
-| explicit-ctx    |    39.3 |              25.45 |    40.78 |                  1.72 |
+| legend          | rx_drop | nanosec per pkt | saved ns | step ns improve |
+|-----------------+---------+-----------------+----------+-----------------|
+| baseline        |    15.1 |           66.23 |       0. |               0 |
+| XDP_ATTACH      |    17.1 |           58.48 |     7.75 |            7.75 |
+| remove-indirect |    23.4 |           42.74 |    23.49 |           15.74 |
+| no-case-switch  |    31.5 |           31.75 |    34.48 |           10.99 |
+| various         |    36.8 |           27.17 |    39.06 |            4.58 |
+| explicit-ctx    |    39.3 |           25.45 |    40.78 |            1.72 |
 #+TBLFM: $3=(1/$2)*(1000);%.2f::$4=(@2$3)-$3::$5=@-1$3-$3::@2$5=0
 
 
@@ -156,6 +156,80 @@ file:bar_chart_horizontal.svg
 
 Bar Chart Horizontal for RX-drop with AF_XDP
 
+* Data02                  :noexport:
+
+#+tblname: data02
+| legend                   | color     | rx_drop | tx_push | l2fwd |
+|--------------------------+-----------+---------+---------+-------|
+| AF_XDP run-to-completion | xkcd:blue |    39.1 |    68.0 |  22.4 |
+| AF_XDP poll()            | skyblue   |    30.4 |    51.1 |  16.4 |
+| DPDK scalar driver       | gray      |    52.8 |    64.2 |  20.0 |
+| DPDK vector driver       | yellow    |    73.0 |    73.7 |  22.5 |
+
+* Example-4: Python
+
+#+BEGIN_SRC python :var fname="solutions_compare.svg" :var data=data02 :results file
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+import numpy as np
+mpl.rcParams['figure.figsize'] = [8.0+5, 4.5]
+
+legends = [a[0] for a in data]
+colors  = [a[1] for a in data]
+n_groups = 3
+
+# Extract data from org-table
+xdp1 =  data[0][2:5]
+xdp2 =  data[1][2:5]
+dpdk1 = data[2][2:5]
+dpdk2 = data[3][2:5]
+
+fig, ax = plt.subplots()
+index = np.arange(n_groups)
+bar_width = 0.20
+opacity = 0.69
+
+ax.set_ylabel('Mpps')
+ax.set_title('Comparison with DPDK')
+
+rect0 = ax.bar(index,             xdp1,  bar_width, align='center', alpha=opacity,
+        edgecolor='black', color=colors[0], label=legends[0])
+rect1 = ax.bar(index+bar_width,   xdp2,  bar_width, align='center', alpha=opacity,
+        edgecolor='black', color=colors[1], label=legends[1])
+rect2 = ax.bar(index+bar_width*2, dpdk1, bar_width, align='center', alpha=opacity,
+        edgecolor='black', color=colors[2], label=legends[2])
+rect3 = ax.bar(index+bar_width*3, dpdk2, bar_width, align='center', alpha=opacity,
+        edgecolor='black', color=colors[3], label=legends[3])
+
+ax.set_xticks(index + bar_width)
+ax.set_xticklabels(('rx_drop', 'tx_push', 'l2fwd'))
+
+def autolabel(rects):
+    # attach some text labels
+    for rect in rects:
+        height = rect.get_height()
+        ax.text(rect.get_x() + rect.get_width()/2., height,
+                height, ha='center', va='bottom')
+
+autolabel(rect0)
+autolabel(rect1)
+autolabel(rect2)
+autolabel(rect3)
+
+plt.legend()
+fig.savefig(fname)
+return fname
+#+END_SRC
+
+#+RESULTS:
+[[file:solutions_compare.svg]]
+
+
+* Slide: Example-4: Comparison against DPDK                          :export:
+
+file:solutions_compare.svg
+
+Compare AF_XDP against DPDK performance
 
 * Emacs tricks
 

--- a/conference/FOSDEM2019/slides_examples.org
+++ b/conference/FOSDEM2019/slides_examples.org
@@ -24,15 +24,17 @@ Examples in section "Plotting with python"
 * Example-1: Data                                                    :export:
 
 #+tblname: data01
-| legend       | rx_drop | nanosec per packet |  saved ns |
-|--------------+---------+--------------------+-----------|
-| baseline     |    15.1 |          66.225166 |        0. |
-| ATTACH       |    17.1 |          58.479532 |  7.745634 |
-| 1-indirect   |    23.4 |          42.735043 | 23.490123 |
-| RM-switch    |    31.5 |          31.746032 | 34.479134 |
-| various      |    36.8 |          27.173913 | 39.051253 |
-| ctx          |    39.3 |          25.445293 | 40.779873 |
-#+TBLFM: $3=(1/$2)*(1000)::$4=(@2$3)-$3
+| legend     | rx_drop | nanosec per packet | saved ns |
+|------------+---------+--------------------+----------|
+| baseline   |    15.1 |              66.23 |       0. |
+| ATTACH     |    17.1 |              58.48 |     7.75 |
+| 1-indirect |    23.4 |              42.74 |    23.49 |
+| RM-switch  |    31.5 |              31.75 |    34.48 |
+| various    |    36.8 |              27.17 |    39.06 |
+| ctx        |    39.3 |              25.45 |    40.78 |
+#+TBLFM: $3=(1/$2)*(1000);%.2f::$4=(@2$3)-$3
+
+Tables can also be exported in a slide
 
 * Example-1: Python pyplot code                                    :noexport:
 

--- a/conference/FOSDEM2019/slides_examples.org
+++ b/conference/FOSDEM2019/slides_examples.org
@@ -78,7 +78,9 @@ objects = [a[0] for a in data]
 y_pos = np.arange(len(objects))
 performance = [a[1] for a in data]
 
-plt.bar(y_pos, performance, align='center', alpha=0.6)
+my_colors = ['xkcd:blue', 'xkcd:orange', 'xkcd:green', 'xkcd:red',
+             'xkcd:purple', 'xkcd:brown' ]
+plt.bar(y_pos, performance, align='center', alpha=0.6, color=my_colors)
 plt.xticks(y_pos, objects)
 plt.ylabel('Mpps')
 plt.title('AF_XDP - RX-drop')
@@ -114,7 +116,11 @@ objects = [a[0] for a in data]
 y_pos = np.arange(len(objects))
 performance = [a[1] for a in data]
 
-plt.barh(y_pos, performance, align='center', alpha=0.6)
+'''Extract colors in the default property cycle'''
+prop_cycle = plt.rcParams['axes.prop_cycle']
+my_colors = prop_cycle.by_key()['color']
+
+plt.barh(y_pos, performance, align='center', alpha=0.6, color=my_colors)
 plt.yticks(y_pos, objects)
 plt.xlabel('Mpps')
 plt.title('AF_XDP - RX-drop')

--- a/conference/FOSDEM2019/slides_examples.org
+++ b/conference/FOSDEM2019/slides_examples.org
@@ -1,0 +1,70 @@
+#  -*- fill-column: 79; -*-
+#+TITLE: Slide examples with data
+#+AUTHOR: Jesper Dangaard Brouer
+#+EMAIL: brouer@redhat.com
+#+REVEAL_THEME: redhat
+#+REVEAL_TRANS: linear
+#+REVEAL_MARGIN: 0
+#+REVEAL_EXTRA_JS: { src: './reveal.js/js/custom-fosdem2019.js'}
+#+REVEAL_EXTRA_CSS: ./reveal.js/css/custom-adjust-logo.css
+#+OPTIONS: reveal_center:nil reveal_control:t reveal_history:nil
+#+OPTIONS: reveal_width:1600 reveal_height:900
+#+OPTIONS: ^:nil tags:nil toc:nil num:nil ':t
+
+* Intro
+
+Playing different ways to represent data via using org-mode tables.
+
+Found online resources:
+- https://acaird.github.io/2015/09/04/plots-from-org-mode-tables
+
+Examples in section "Plotting with python"
+- http://ehneilsen.net/notebook/orgExamples/org-examples.html
+
+* Example-1: Data                                                    :export:
+
+#+tblname: data01
+| legend       | rx_drop | nanosec per packet |  saved ns |
+|--------------+---------+--------------------+-----------|
+| baseline     |    15.1 |          66.225166 |        0. |
+| XDP_ATTACH   |    17.1 |          58.479532 |  7.745634 |
+| RM-indirect  |    23.4 |          42.735043 | 23.490123 |
+| RM-switch    |    31.5 |          31.746032 | 34.479134 |
+| various      |    36.8 |          27.173913 | 39.051253 |
+| explicit-ctx |    39.3 |          25.445293 | 40.779873 |
+#+TBLFM: $3=(1/$2)*(1000)::$4=(@2$3)-$3
+
+* Example-1: Python pyplot code                                    :noexport:
+
+Execute python code in emacs via keyboard shortcut: =C-c C-c=
+
+#+BEGIN_SRC python :var fname="rx_drop.png" :var data=data01 :results file
+import matplotlib.pyplot as plt
+
+txt, y, z, a = zip(*data)
+
+fig = plt.figure()
+axes = fig.add_subplot(1,1,1)
+axes.plot(txt, y, marker='o')
+fig.savefig(fname)
+
+return fname
+#+END_SRC
+
+#+RESULTS:
+[[file:rx_drop.png]]
+
+* Example-1 slide                                                    :export:
+
+file:rx_drop.png
+
+Not much room for describing the figure
+
+* Emacs tricks
+
+# Local Variables:
+# org-reveal-title-slide: "<h1 class=\"title\">%t</h1>
+# <h2 class=\"author\">Jesper Dangaard Brouer (Red Hat)<br/></h2>
+# <h3>Data Examples<br/>in org-mode</h3>"
+# org-export-filter-headline-functions: ((lambda (contents backend info) (replace-regexp-in-string "Slide: " "" contents)))
+# End:


### PR DESCRIPTION
Created a separate presentation file: [FOSDEM2019/slides_examples.org](https://github.com/xdp-project/xdp-project/blob/master/conference/FOSDEM2019/slides_examples.org)

To experiment with placing graph-data directly in org-mode file, in org-mode tables, and then accessing them from inline python code, that use [matplotlib](https://pythonspot.com/matplotlib/) to generate SVG graphs. Had a lot of fun learning org-mode tables, and inline python code.

Related to issue #4 