### PR TITLE
Update references for newly added netsec driver

### DIFF
--- a/areas/drivers.org
+++ b/areas/drivers.org
@@ -10,7 +10,7 @@ Top-level headings indicate category, as explained in [[file:../xdp-project.org]
 
 Very few drivers support XDP_REDIRECT.
 
-HW drivers: ixgbe, i40e, mlx5
+HW drivers: ixgbe, i40e, mlx5, netsec
 
 SW drivers: veth, tun (tuntap), virtio_net
 

--- a/areas/drivers/README.org
+++ b/areas/drivers/README.org
@@ -25,6 +25,7 @@ The following drivers support XDP in upstream kernels.
 - tun
 - veth
 - virtio_net
+- netsec
 
 * Other sources
 

--- a/people.org
+++ b/people.org
@@ -57,6 +57,7 @@ Driver developers:
 - Michael S. Tsirkin (ptr_ring)
 - Edward Cree (sfc)
 - Toshiaki Makita <makita.toshiaki@lab.ntt.co.jp> (veth)
+- Ilias Apalodimas <ilias.apalodimas@linaro.org> (netsec)
 
 Developers unsorted:
 - PJ (still waiting for data_meta work)
@@ -86,3 +87,6 @@ Drivers that will get XDP and use page_pool:
  - driver: mlx5
  - driver: mvpp2  board: Macchiatobin
  - driver: mvneta board: espressobin + Turris-Omnia
+
+Drivers with XDP and page_pool usage:
+ - driver: netsec board: Socionext DeveloperBox


### PR DESCRIPTION
Driver uses page_pool API and has XDP support

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>