### PR TITLE
Notes on understanding how kernel can use BTF

### DIFF
--- a/areas/arm64/board_nxp_ls1088/nxp-board01-notes.org
+++ b/areas/arm64/board_nxp_ls1088/nxp-board01-notes.org
@@ -28,8 +28,8 @@ refer to =/boot/Image= under Linux).
 
 In U-Boot console:
 #+begin_src sh
-setenv kernel_image Image3
 setenv othbootargs arm-smmu.disable_bypass=0
+setenv kernel_image Image3
 boot
 #+end_src
 

--- a/areas/core/BTF_01_notes.org
+++ b/areas/core/BTF_01_notes.org
@@ -223,3 +223,33 @@ Given I manually found this was related to =map_check_no_btf=, it is
 possible to search for "map_check_no_btf" and indirectly see that it fails
 as the code calls =btf_put()=.
 
+*** Propose changing return code
+
+Proposal for changing the return code:
+ - https://lore.kernel.org/bpf/159050511046.148183.1806612131878890638.stgit@firesoul
+
+#+begin_quote
+bpf: Fix map_check_no_btf return code
+
+When a BPF-map type doesn't support having a BTF info associated, the
+bpf_map_ops->map_check_btf is set to map_check_no_btf(). This function
+map_check_no_btf() currently returns -ENOTSUPP, which result in a very
+confusing error message in libbpf, see below.
+
+The errno ENOTSUPP is part of the kernels internal errno in file
+include/linux/errno.h. As is stated in the file, these "should never be seen
+by user programs."
+
+Choosing errno EUCLEAN instead, which translated to "Structure needs
+cleaning" by strerror(3). This hopefully leads people to think about data
+structures which BTF is all about.
+
+Before this change end-users of libbpf will see:
+ libbpf: Error in bpf_create_map_xattr(cpu_map):ERROR: strerror_r(-524)=22(-524). Retrying without BTF.
+
+After this change end-users of libbpf will see:
+ libbpf: Error in bpf_create_map_xattr(cpu_map):Structure needs cleaning(-117). Retrying without BTF.
+
+Fixes: e8d2bec04579 ("bpf: decouple btf from seq bpf fs dump and enable more maps")
+Signed-off-by: Jesper Dangaard Brouer <brouer@redhat.com>
+#+end_quote

--- a/areas/core/BTF_01_notes.org
+++ b/areas/core/BTF_01_notes.org
@@ -47,5 +47,13 @@ See code function =btf_find_spin_lock()= in kernel/bpf/btf.c
  - [[https://elixir.bootlin.com/linux/v5.6.14/ident/btf_find_spin_lock][Search btf_find_spin_lock]]
  - Code: [[https://elixir.bootlin.com/linux/v5.6.14/source/kernel/bpf/btf.c#L2327][btf_find_spin_lock()]]
 
-I think it will be overkill for our use-case, to allow dynamic offset.
+I think it will be overkill for our use-case, to allow dynamic offset. On
+the-other-hand, allowing dynamic offset will make it easier to extend the
+value data-type.
+
+Even allowing users to add their own user specific "opaque" info. For our
+=devmap= use-case, it could be practical to store the egress MAC or VLAN
+address directly in the devmap.
+
+
 

--- a/areas/core/BTF_01_notes.org
+++ b/areas/core/BTF_01_notes.org
@@ -55,5 +55,9 @@ Even allowing users to add their own user specific "opaque" info. For our
 =devmap= use-case, it could be practical to store the egress MAC or VLAN
 address directly in the devmap.
 
+*** Insight: name of struct is important
 
+It is the text string ="bpf_spin_lock"= that is used for identifying the
+spinlock. This originates from the BTF info for =struct bpf_spin_lock=. The
+variable name that is chosen for the spinlock is not used.
 

--- a/areas/core/BTF_01_notes.org
+++ b/areas/core/BTF_01_notes.org
@@ -305,4 +305,21 @@ To make this forward-compatible, the area need to be encapsulated in a named
 struct e.g. "storage". As in newer kernel, we want to add new members.
 
 
+** Existing functions
+
+Q: What existing function exist that compared two BTF layouts?
+
+
+
+#+begin_src C
+/* Compare BTFs of given program with BTF of target program */
+
+int btf_check_type_match(
+	struct bpf_verifier_env *env, struct bpf_prog *prog,
+	struct btf *btf2, const struct btf_type *t2)
+{
+ [...]
+ calls btf_check_func_type_match() 
+#+end_src
+
 

--- a/areas/core/BTF_01_notes.org
+++ b/areas/core/BTF_01_notes.org
@@ -2,14 +2,15 @@
 #+Title: BTF (Bpf Type Format) notes
 #+OPTIONS: ^:nil
 
-The BPF Type Format (BTF) is a really cool feature that allows us to
+The BPF Type Format (BTF) is a [[https://facebookmicrosites.github.io/bpf/blog/2018/11/14/btf-enhancement.html][really cool feature]] that allows us to
 describe data types used in e.g. BPF-maps (both key and value).
 
 The [[https://www.kernel.org/doc/html/latest/bpf/btf.html#bpf-type-format-btf][kernel BTF documentation]] is all about encoding details, and not about
 how to use BTF.
 
 This is my notes for trying to understand how to use BTF
-*from within the kernel*.
+*from within the kernel*.  The last part is important, the target audience
+of this document are other kernel developers.
 
 * Motivation
 

--- a/areas/core/BTF_01_notes.org
+++ b/areas/core/BTF_01_notes.org
@@ -226,7 +226,8 @@ as the code calls =btf_put()=.
 *** Propose changing return code
 
 Proposal for changing the return code:
- - https://lore.kernel.org/bpf/159050511046.148183.1806612131878890638.stgit@firesoul
+ - V1: https://lore.kernel.org/bpf/159050511046.148183.1806612131878890638.stgit@firesoul
+ - V2: https://lore.kernel.org/bpf/159057923399.191121.11186124752660899399.stgit@firesoul
 
 #+begin_quote
 bpf: Fix map_check_no_btf return code
@@ -237,19 +238,34 @@ map_check_no_btf() currently returns -ENOTSUPP, which result in a very
 confusing error message in libbpf, see below.
 
 The errno ENOTSUPP is part of the kernels internal errno in file
-include/linux/errno.h. As is stated in the file, these "should never be seen
-by user programs."
+include/linux/errno.h. As is stated in the file, these "should never be
+seen by user programs". This is not a not a standard Unix error.
 
-Choosing errno EUCLEAN instead, which translated to "Structure needs
-cleaning" by strerror(3). This hopefully leads people to think about data
-structures which BTF is all about.
+This should likely have been EOPNOTSUPP instead. This seems to be a common
+mistake, which even checkpatch tried to catch see commit 6b9ea5ff5abd
+("checkpatch: warn about uses of ENOTSUPP").
 
 Before this change end-users of libbpf will see:
  libbpf: Error in bpf_create_map_xattr(cpu_map):ERROR: strerror_r(-524)=22(-524). Retrying without BTF.
 
 After this change end-users of libbpf will see:
- libbpf: Error in bpf_create_map_xattr(cpu_map):Structure needs cleaning(-117). Retrying without BTF.
+ libbpf: Error in bpf_create_map_xattr(cpu_map):Operation not supported(-95). Retrying without BTF.
+
+V2: Use EOPNOTSUPP instead of EUCLEAN.
 
 Fixes: e8d2bec04579 ("bpf: decouple btf from seq bpf fs dump and enable more maps")
 Signed-off-by: Jesper Dangaard Brouer <brouer@redhat.com>
 #+end_quote
+
+Andrii suggests: to use EOPNOTSUPP (instead of errno ENOTSUPP)
+
+#+begin_example
+libbpf: Error in bpf_create_map_xattr(cpu_map):Operation not supported(-95). Retrying without BTF.
+#+end_example
+
+V2: Add --cc kuba@kernel.org
+#+begin_src sh
+stg mail --version='bpf-next V2' --cc meup \
+ --to bpf --cc daniel --cc alexei --cc jakub --cc andrii \
+  fix_map_check_no_btf
+#+end_src

--- a/areas/core/BTF_01_notes.org
+++ b/areas/core/BTF_01_notes.org
@@ -269,3 +269,40 @@ stg mail --version='bpf-next V2' --cc meup \
  --to bpf --cc daniel --cc alexei --cc jakub --cc andrii \
   fix_map_check_no_btf
 #+end_src
+
+
+* Code notes
+
+** How to reject?
+
+If loading BPF-map + BTF fails, then libbpf will retry without BTF.
+
+Thus, to requires BTF we need (ability) to reject a map_create, when there
+isn't any BTF id.
+
+#+begin_src C
+static int dev_map_init_map(struct bpf_dtab *dtab, union bpf_attr *attr)
+{
+
+	/* Enforce BTF for userspace, unless dealing with legacy kABI */
+	if (attr->value_size != 4 &&
+	    (!attr->btf_key_type_id || !attr->btf_value_type_id))
+		return -EOPNOTSUPP;
+#+end_src
+
+** devmap read-only from eBPF side
+
+See commit 0cdbb4b09a06 ("devmap: Allow map lookups from eBPF")
+
+** Extra storage space argument
+
+With BTF we can allow userspace to store extra data in map-value in the
+devmap. It does require a lookup in the "devmap-egress" XDP-prog (likely
+with it's own ifindex), but prog that need such extra-info would need to do
+a map lookup anyhow (and we know devmap will be in L1 cache).
+
+To make this forward-compatible, the area need to be encapsulated in a named
+struct e.g. "storage". As in newer kernel, we want to add new members.
+
+
+

--- a/areas/core/BTF_01_notes.org
+++ b/areas/core/BTF_01_notes.org
@@ -1,0 +1,13 @@
+# -*- fill-column: 76; -*-
+#+Title: BTF (Bpf Type Format) notes
+#+OPTIONS: ^:nil
+
+The BPF Type Format (BTF) is a really cool feature that allows us to
+describe data types used in e.g. BPF-maps (both key and value).
+
+The [[https://www.kernel.org/doc/html/latest/bpf/btf.html#bpf-type-format-btf][kernel BTF documentation]] is all about encoding details, and not about
+how to use BTF.
+
+This is my notes for trying to understand how to use BTF
+*from within the kernel*.
+

--- a/areas/core/BTF_01_notes.org
+++ b/areas/core/BTF_01_notes.org
@@ -50,7 +50,7 @@ TODO: Investigate their approach.
 Main introducing commit:
 - [[https://git.kernel.org/torvalds/c/d83525ca62cf][d83525ca62cf]] ("bpf: introduce bpf_spin_lock")
 
-The ="bpf_spin_lock"= approach is significantly more advanced than we
+The "bpf_spin_lock" approach is significantly more advanced than we
 actually need. So, need to figure out what parts we want to leverage.
 
 *** Dynamic offset
@@ -75,4 +75,31 @@ address directly in the devmap.
 It is the text string ="bpf_spin_lock"= that is used for identifying the
 spinlock. This originates from the BTF info for =struct bpf_spin_lock=. The
 variable name that is chosen for the spinlock is not used.
+
+
+** map_check_btf
+
+The function =map_check_btf()= have an explicit call to
+=btf_find_spin_lock=. But more interesting each map can implement it's own
+callback =map->ops->map_check_btf()=.
+
+#+begin_src C
+static int map_check_btf(struct bpf_map *map, const struct btf *btf,
+			 u32 btf_key_id, u32 btf_value_id)
+{
+ [...]
+	if (map->ops->map_check_btf)
+		ret = map->ops->map_check_btf(map, btf, key_type, value_type);
+}
+#+end_src
+
+The =map_create()= calls =map_check_btf()=, *after* =map_alloc()= have
+allocated map. Usually =attr->key_size= and =attr->value_size= are used in
+the map specific map_alloc (e.g. =cpu_map_alloc()=) to reject creation of
+the map, if the key or value size are incorrect.  Depending on how dynamic
+we want this, these size checks might need to be relaxed.
+
+
+
+* Code ideas
 

--- a/areas/core/BTF_01_notes.org
+++ b/areas/core/BTF_01_notes.org
@@ -99,8 +99,6 @@ the map specific map_alloc (e.g. =cpu_map_alloc()=) to reject creation of
 the map, if the key or value size are incorrect.  Depending on how dynamic
 we want this, these size checks might need to be relaxed.
 
-
-
 *** Maps using map_check_btf
 
 Key =BTF_KIND_INT= validation example in array_map_check_btf().
@@ -108,8 +106,6 @@ Key =BTF_KIND_INT= validation example in array_map_check_btf().
 Other candidates:
  - cgroup_storage_check_btf
  - trie_check_btf
-
-
 
 * Experimenting
 
@@ -270,7 +266,6 @@ stg mail --version='bpf-next V2' --cc meup \
   fix_map_check_no_btf
 #+end_src
 
-
 * Code notes
 
 ** How to reject?
@@ -309,8 +304,6 @@ struct e.g. "storage". As in newer kernel, we want to add new members.
 
 Q: What existing function exist that compared two BTF layouts?
 
-
-
 #+begin_src C
 /* Compare BTFs of given program with BTF of target program */
 
@@ -319,7 +312,5 @@ int btf_check_type_match(
 	struct btf *btf2, const struct btf_type *t2)
 {
  [...]
- calls btf_check_func_type_match() 
+ calls btf_check_func_type_match()
 #+end_src
-
-

--- a/areas/core/BTF_01_notes.org
+++ b/areas/core/BTF_01_notes.org
@@ -23,3 +23,29 @@ The practical use-case is extending =devmap= and =cpumap= with a BPF-prog
 that is run when an =xdp_frame= is redirected to a entry in the map.
 
 David Ahern have [[https://lore.kernel.org/netdev/20200522010526.14649-1-dsahern@kernel.org/][posted RFC]] on extending =devmap=.
+
+* Investigate other code
+
+The ="bpf_spin_lock"= changes does a lot of checks based on BTF.
+
+TODO: Investigate their approach.
+
+** bpf_spin_lock approach
+
+Main introducing commit:
+- [[https://git.kernel.org/torvalds/c/d83525ca62cf][d83525ca62cf]] ("bpf: introduce bpf_spin_lock")
+
+The ="bpf_spin_lock"= approach is significantly more advanced than we
+actually need. So, need to figure out what parts we want to leverage.
+
+*** Dynamic offset
+
+A data-type =struct bpf_spin_lock anyname= can be located at any (aligned)
+offset in the map value.
+
+See code function =btf_find_spin_lock()= in kernel/bpf/btf.c
+ - [[https://elixir.bootlin.com/linux/v5.6.14/ident/btf_find_spin_lock][Search btf_find_spin_lock]]
+ - Code: [[https://elixir.bootlin.com/linux/v5.6.14/source/kernel/bpf/btf.c#L2327][btf_find_spin_lock()]]
+
+I think it will be overkill for our use-case, to allow dynamic offset.
+

--- a/areas/core/BTF_01_notes.org
+++ b/areas/core/BTF_01_notes.org
@@ -101,5 +101,90 @@ we want this, these size checks might need to be relaxed.
 
 
 
-* Code ideas
+*** Maps using map_check_btf
 
+Key =BTF_KIND_INT= validation example in array_map_check_btf().
+
+Other candidates:
+ - cgroup_storage_check_btf
+ - trie_check_btf
+
+
+
+* Experimenting
+
+** What happen: Adding BTF to cpumap
+
+Add BTF description when creating cpumap (=BPF_MAP_TYPE_CPUMAP=), without
+modifying kernel. This caused libbpf to fail with these error/warning
+message:
+
+#+begin_example
+libbpf: Error in bpf_create_map_xattr(cpu_map):ERROR: strerror_r(-524)=22(-524). Retrying without BTF.
+
+libbpf: Error in bpf_create_map_xattr(cpu_map):Invalid argument(-22). Retrying without BTF.
+#+end_example
+
+As libbpf retries without BTF info it succeeds anyhow, e.g this is just a
+warning. The first error message does look a bit odd and originates from
+this code:
+
+#+begin_src C
+	map->fd = bpf_create_map_xattr(&create_attr);
+	if (map->fd < 0 && (create_attr.btf_key_type_id ||
+			    create_attr.btf_value_type_id)) {
+		char *cp, errmsg[STRERR_BUFSIZE];
+		int err = -errno;
+
+		cp = libbpf_strerror_r(err, errmsg, sizeof(errmsg));
+		pr_warn("Error in bpf_create_map_xattr(%s):%s(%d). Retrying without BTF.\n",
+			map->name, cp, err);
+		create_attr.btf_fd = 0;
+		create_attr.btf_key_type_id = 0;
+		create_attr.btf_value_type_id = 0;
+		map->btf_key_type_id = 0;
+		map->btf_value_type_id = 0;
+		map->fd = bpf_create_map_xattr(&create_attr);
+	}
+#+end_src
+
+The strange error message comes when I added a slightly more advanced BTF
+struct as value.
+
+#+begin_src C
+struct cpu_map_value {
+	__u32 qsize;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_CPUMAP);
+	__type(key, u32);
+	__type(value, struct cpu_map_value);
+	__uint(max_entries, MAX_CPUS);
+} cpu_map SEC(".maps");
+#+end_src
+
+Trying to debug what kernel function call that returns this error.
+
+The BPF tracepoint were removed in commit 4d220ed0f814 ("bpf: remove
+tracepoints from bpf core") (Author: Alexei Starovoitov). This makes it
+harder debug and isolate 'map_create' function call (as it get inlined).
+
+
+
+#+begin_example
+ perf trace record -o /tmp/perf.data -e syscalls:sys_enter_bpf \
+  ./xdp_redirect_cpu -F --dev mlx5p1 --q 1024 --cpu 4 --prog xdp_cpu_map0
+#+end_example
+
+Finding BPF syscall to ftrace:
+#+begin_example
+ $ sudo trace-cmd list -f SyS_bpf
+ __x64_sys_bpf
+ __ia32_sys_bpf
+#+end_example
+
+In another terminal record via trace-cmd:
+#+begin_example
+sudo trace-cmd record -p function_graph -g __x64_sys_bpf
+#+end_example

--- a/areas/core/BTF_01_notes.org
+++ b/areas/core/BTF_01_notes.org
@@ -25,9 +25,23 @@ that is run when an =xdp_frame= is redirected to a entry in the map.
 
 David Ahern have [[https://lore.kernel.org/netdev/20200522010526.14649-1-dsahern@kernel.org/][posted RFC]] on extending =devmap=.
 
+** Reason for dynamic map-value
+
+The reason I want to have the map-value more dynamic (both for =devmap= and
+=cpumap=) is to allow extending this later. Adding an XDP-prog to run is
+only the first step.
+
+Future extensions that could happen:
+
+ 1) Add XDP-prog that see packet(s) when ndo_xdp_xmit fails.
+
+ 2) Add overflow-queue object/setup that hold packets on ndo_xdp_xmit fails.
+
+ 3) Add TX-queue object/setup that determine TX-queue in ndo_xdp_xmit call.
+
 * Investigate other code
 
-The ="bpf_spin_lock"= changes does a lot of checks based on BTF.
+The "bpf_spin_lock" changes does a lot of checks based on BTF.
 
 TODO: Investigate their approach.
 

--- a/areas/core/BTF_01_notes.org
+++ b/areas/core/BTF_01_notes.org
@@ -166,16 +166,32 @@ struct {
 
 Trying to debug what kernel function call that returns this error.
 
+Using =strace= it is easy trace all BPF syscalls (=-e trace=bpf=) and then
+filter to the ones that fails (=--failed-only or -Z=):
+
+#+begin_example
+sudo strace -e trace=bpf --failed-only ./xdp_redirect_cpu -F --dev mlx5p1 --q 1024 --cpu 4 --prog xdp_cpu_map0 
+bpf(BPF_MAP_CREATE, {map_type=BPF_MAP_TYPE_CPUMAP, key_size=4, value_size=4, max_entries=8192, map_flags=0, inner_map_fd=0, map_name="cpu_map", map_ifindex=0, btf_fd=3, btf_key_type_id=7, btf_value_type_id=27, btf_vmlinux_value_type_id=0}, 120) = -1 ENOTSUPP (Unknown error 524)
+libbpf: Error in bpf_create_map_xattr(cpu_map):ERROR: strerror_r(-524)=22(-524). Retrying without BTF.
+#+end_example
+
+It shows what we already knows, that =BPF_MAP_CREATE= fails with error
+code 524. This errno is defined as =ENOTSUPP=, and is part of the kernels
+internal errno in file [[https://github.com/torvalds/linux/blob/master/include/linux/errno.h][include/linux/errno.h]]. As is stated in the file,
+these "should never be seen by user programs."
+
+#+begin_example
+#define ENOTSUPP        524     /* Operation is not supported */
+#+end_example
+
+What we really wanted was to identify and record the kernel functions
+involved to figure out what kernel function fails.
+
 The BPF tracepoint were removed in commit 4d220ed0f814 ("bpf: remove
 tracepoints from bpf core") (Author: Alexei Starovoitov). This makes it
 harder debug and isolate 'map_create' function call (as it get inlined).
 
-
-
-#+begin_example
- perf trace record -o /tmp/perf.data -e syscalls:sys_enter_bpf \
-  ./xdp_redirect_cpu -F --dev mlx5p1 --q 1024 --cpu 4 --prog xdp_cpu_map0
-#+end_example
+*** Using ftrace and trace-cmd
 
 Finding BPF syscall to ftrace:
 #+begin_example
@@ -188,3 +204,22 @@ In another terminal record via trace-cmd:
 #+begin_example
 sudo trace-cmd record -p function_graph -g __x64_sys_bpf
 #+end_example
+
+Run the failing command:
+#+begin_example
+sudo ./xdp_redirect_cpu -F --dev mlx5p1 --q 1024 --cpu 4 --prog xdp_cpu_map0
+libbpf: Error in bpf_create_map_xattr(cpu_map):ERROR: strerror_r(-524)=22(-524). Retrying without BTF.
+libbpf: map 'cpu_map': failed to create: ERROR: strerror_r(-524)=22(-524)
+libbpf: failed to load object './xdp_redirect_cpu_kern.o'
+#+end_example
+
+Viewing the result via:
+#+begin_example
+trace-cmd report | less
+#+end_example
+
+In general there is way too much data. Thus it is hard to use for anything.
+Given I manually found this was related to =map_check_no_btf=, it is
+possible to search for "map_check_no_btf" and indirectly see that it fails
+as the code calls =btf_put()=.
+

--- a/areas/core/BTF_01_notes.org
+++ b/areas/core/BTF_01_notes.org
@@ -11,3 +11,15 @@ how to use BTF.
 This is my notes for trying to understand how to use BTF
 *from within the kernel*.
 
+* Motivation
+
+Specifically I want to figure out, if we can use BTF to allow for
+dynamically extending and changing e.g. the map value type, and still have
+the kernel validate the contents.
+
+** Use-case: devmap and cpumap
+
+The practical use-case is extending =devmap= and =cpumap= with a BPF-prog
+that is run when an =xdp_frame= is redirected to a entry in the map.
+
+David Ahern have [[https://lore.kernel.org/netdev/20200522010526.14649-1-dsahern@kernel.org/][posted RFC]] on extending =devmap=.

--- a/areas/core/BTF_02_proposed_usage.org
+++ b/areas/core/BTF_02_proposed_usage.org
@@ -169,7 +169,42 @@ running (and compiled with new UAPI header) against a newer kernel.
 
 ** Cover-letter
 
+#+begin_quote
+bpf: avoid using/returning file descriptor value zero
 
+Make it easier to handle UAPI/kABI extensions by avoid BPF using/returning
+file descriptor value zero. Use this in recent devmap extension to keep
+older applications compatible with newer kernels.
+
+For special type maps (e.g. devmap and cpumap) the map-value data-layout is
+a configuration interface. This is a kernel Application Binary Interface
+(kABI) that can only be tail extended. Thus, new members (and thus features)
+can only be added to the end of this structure, and the kernel uses the
+map->value_size from userspace to determine feature set 'version'.
+
+For this kind of kABI to be extensible and backward compatible, is it common
+that new members/fields (that represent a new feature) in the struct are
+initialised as zero, which indicate that the feature isn't used. This makes
+it possible to write userspace applications that are unaware of new kernel
+features, but just include latest uapi headers, zero-init struct and
+populate features it knows about.
+
+The recent extension of devmap with a bpf_prog.fd requires end-user to
+supply the file-descriptor value minus-1 to communicate that the features
+isn't used. This isn't compatible with the described kABI extension model.
+#+end_quote
+
+*** stg mail
+
+#+begin_example
+stg mail --version="bpf" --cc meup --edit-cover \
+ --to ahern --to bpf --cc netdev --cc daniel --to alexei \
+ --cc andrii --cc lore \
+ 01-start_fd_1..03-tools_and_selftests
+#+end_example
+
+Message-ID: <159163498340.1967373.5048584263152085317.stgit@firesoul>
+- [[https://lore.kernel.org/bpf/159163498340.1967373.5048584263152085317.stgit@firesoul/][link]]
 
 ** Patch-1: bpf: syscall to start at file-descriptor 1
 
@@ -209,4 +244,13 @@ value zero, we can remove the minus-1 checks, and have zero mean feature
 isn't used.
 
 Fixes: fbee97feed9b ("bpf: Add support to attach bpf program to a devmap entry")
+#+end_quote
+
+** Patch-3:
+
+#+begin_quote
+bpf: selftests and tools use struct bpf_devmap_val from uapi
+
+Sync tools uapi bpf.h header file and selftests that use struct
+bpf_devmap_val.
 #+end_quote

--- a/areas/core/BTF_02_proposed_usage.org
+++ b/areas/core/BTF_02_proposed_usage.org
@@ -2,7 +2,17 @@
 #+Title: BTF (Bpf Type Format) proposal for dynamic map-values
 #+OPTIONS: ^:nil
 
+This approach of /dynamic map-values via BTF/ was *rejected upstream*:
+ - https://lore.kernel.org/netdev/159119908343.1649854.17264745504030734400.stgit@firesoul/
 
+It implements a fully dynamic UAPI/ABI that userspace defines via defining
+the struct layout via BTF (at map_create), and the kernel-side validates
+BTF-info and restrict possible struct member names, which are remapped to
+offsets inside the kernel.
+
+Keeping this document around, because the link above show code on how to use
+kernel functions for walking and interacting with the BTF layout from the
+kernel side.
 
 * Patches attempt-1: Rejected
 [[https://lore.kernel.org/netdev/159076794319.1387573.8722376887638960093.stgit@firesoul/][link]]
@@ -127,7 +137,10 @@ $ git whatchanged d39aec79e5923bf984df991ffe51d4a2b7a9e746
 
 * Patchset: attempt-2
 
+Rejected with unproductive argument "make no sense" [[https://lore.kernel.org/netdev/20200604174806.29130b81@carbon/][link]].
+
 ** PATCH: bpf: devmap dynamic map-value area based on BTF
+[[https://lore.kernel.org/netdev/159119908343.1649854.17264745504030734400.stgit@firesoul/][link]]
 
 #+begin_quote
 bpf: devmap dynamic map-value area based on BTF

--- a/areas/core/BTF_02_proposed_usage.org
+++ b/areas/core/BTF_02_proposed_usage.org
@@ -135,7 +135,7 @@ $ git whatchanged d39aec79e5923bf984df991ffe51d4a2b7a9e746
  tools/testing/selftests/bpf/progs/test_xdp_with_devmap_helpers.c
 #+end_example
 
-* Patchset: attempt-2
+* Patchset: attempt-2: Good BTF-code example (but rejected)
 
 Rejected with unproductive argument "make no sense" [[https://lore.kernel.org/netdev/20200604174806.29130b81@carbon/][link]].
 

--- a/areas/core/BTF_02_proposed_usage.org
+++ b/areas/core/BTF_02_proposed_usage.org
@@ -157,3 +157,56 @@ stg mail --version="bpf-next V1" --cc meup \
 #+end_src
 
 
+* Patchset: attempt-3 - no FD zero
+
+*New direction*: Simply avoid FD zero is used by BPF
+
+Above attempts tried to solve the kABI issue in a too advanced fashion (via
+making it dynamic via BTF). The *real practical issue* is that it is hard to
+extend a binary API (tail extending the struct) when the value must be
+initialised with something else than zero. As this breaks userspace programs
+running (and compiled with new UAPI header) against a newer kernel.
+
+** Cover-letter
+
+
+
+** Patch-1: bpf: syscall to start at file-descriptor 1
+
+This patch change BPF syscall to avoid returning file descriptor value zero.
+
+As mentioned in cover letter, it is very impractical when extending kABI
+that the file-descriptor value 'zero' is valid, as this requires new fields
+must be initialised as minus-1. First step is to change the kernel such that
+BPF-syscall simply doesn't return value zero as a FD number.
+
+This patch achieves this by similar code to anon_inode_getfd(), with the
+exception of getting unused FD starting from 1. The kernel already supports
+starting from a specific FD value, as this is used by f_dupfd(). It seems
+simpler to replicate part of anon_inode_getfd() code and use this start from
+offset feature, instead of using f_dupfd() handling afterwards.
+
+** Patch-2:
+
+#+begin_quote
+bpf: devmap adjust uapi for attach bpf program
+
+The recent commit fbee97feed9b ("bpf: Add support to attach bpf program to a
+devmap entry"), introduced ability to attach (and run) a separate XDP
+bpf_prog for each devmap entry. A bpf_prog is added via a file-descriptor.
+As zero were a valid FD, not using the feature requires using value minus-1.
+The UAPI is extended via tail-extending struct bpf_devmap_val and using
+map->value_size to determine the feature set.
+
+This will break older userspace applications not using the bpf_prog feature.
+Consider an old userspace app that is compiled against newer kernel
+uapi/bpf.h, it will not know that it need to initialise the member
+bpf_prog.fd to minus-1. Thus, users will be forced to update source code to
+get program running on newer kernels.
+
+As previous patch changed BPF-syscall to avoid returning file descriptor
+value zero, we can remove the minus-1 checks, and have zero mean feature
+isn't used.
+
+Fixes: fbee97feed9b ("bpf: Add support to attach bpf program to a devmap entry")
+#+end_quote

--- a/areas/core/BTF_02_proposed_usage.org
+++ b/areas/core/BTF_02_proposed_usage.org
@@ -60,3 +60,56 @@ into map when compiled with the newer struct. Why, because previously it
 didn't use the bpf_prog feature (and don't want to), but because bpf_prog.fd
 needs to be -1 (to not use the feature) the map-insert now fails.
 
+** Argue in patch description
+
+This allows userspace to skip handling of 'bpf_prog' on map-inserts. The
+bpf_prog.fd feature needs a file-descriptor (pointing to a bpf_prog) as
+input. In-order to not use the feature userspace programs must handle this
+by inserting minus-1 as the file-descriptor number.
+
+Allow skip using this feature, via not including the member 'bpf_prog' in
+the map-value struct, which is propagated/described via BTF.
+
+** Details on ifindex zero
+
+Found an annoying detail. In the original commit that introduced devmap
+546ac1ffb70d ("bpf: add devmap, a map for storing net device references")
+(Author: John Fastabend), inserting ifindex==0 will result in =xchg= with a
+=NULL= pointer, which is basically a delete operation. The map already have
+a delete function call (=dev_map_delete_elem=). This property is not used by
+devmap_hash type. IMHO is it a mistake, and should result in =-EINVAL=
+instead of deleting.
+
+** Issue with Aherns patch
+
+This function is called from =net/core/dev.c= in =generic_xdp_install()= to
+refuse usage of devmap's with "egress" xdp_prog for generic-XDP. This binary
+struct extend-at-end system result in that ALL future extension for devmap
+cannot be used by generic-XDP.
+
+#+begin_src C
+bool dev_map_can_have_prog(struct bpf_map *map)
+{
+	if ((map->map_type == BPF_MAP_TYPE_DEVMAP ||
+	     map->map_type == BPF_MAP_TYPE_DEVMAP_HASH) &&
+	    map->value_size != offsetofend(struct bpf_devmap_val, ifindex))
+		return true;
+
+	return false;
+}
+#+end_src
+
+This can be fixed with the dynamic-BTF proposal. Fixing this is an excellent
+argument why BTF validation is needed.
+
+** Update selftests
+
+Update selftests added in d39aec79e592 ("selftest: Add tests for XDP
+programs in devmap entries") (Author: David Ahern).
+
+#+begin_example
+$ git whatchanged d39aec79e5923bf984df991ffe51d4a2b7a9e746
+ tools/testing/selftests/bpf/prog_tests/xdp_devmap_attach.c
+ tools/testing/selftests/bpf/progs/test_xdp_devmap_helpers.c
+ tools/testing/selftests/bpf/progs/test_xdp_with_devmap_helpers.c
+#+end_example

--- a/areas/core/BTF_02_proposed_usage.org
+++ b/areas/core/BTF_02_proposed_usage.org
@@ -4,7 +4,7 @@
 
 
 
-* Patches
+* Patches attempt-1: Rejected
 
 bpf: dynamic map-value config layout via BTF
 
@@ -49,3 +49,14 @@ This patchset adds a 'storage' member to struct bpf_devmap_val. More
 importantly the struct bpf_devmap_val is made dynamic via leveraging and
 requiring BTF for struct sizes above 4. The only mandatory struct member is
 'ifindex' with a fixed offset of zero.
+
+* Patches attempt-2
+
+** Argue why not a uapi header
+
+Adding struct bpf_devmap_val to UAPI header file is problematic, because a
+userspace program that uses this header file will start to fail inserting
+into map when compiled with the newer struct. Why, because previously it
+didn't use the bpf_prog feature (and don't want to), but because bpf_prog.fd
+needs to be -1 (to not use the feature) the map-insert now fails.
+

--- a/areas/core/BTF_02_proposed_usage.org
+++ b/areas/core/BTF_02_proposed_usage.org
@@ -1,0 +1,51 @@
+# -*- fill-column: 76; -*-
+#+Title: BTF (Bpf Type Format) proposal for dynamic map-values
+#+OPTIONS: ^:nil
+
+
+
+* Patches
+
+bpf: dynamic map-value config layout via BTF
+
+This patchset is based on top of David Ahern's work V3: "bpf: Add support
+for XDP programs in DEVMAP entries"[1]. The purpose is to address the kABI
+interfaces that is introduced in that patchset, before it is released.
+
+[1] https://lore.kernel.org/netdev/20200529052057.69378-1-dsahern@kernel.org
+
+The map-value of these special maps are evolving into configuration
+interface between userspace and kernel. The approach in[1] is to expose a
+binary struct layout that can only be grown in the end of the struct.
+
+With the BTF technology it is possible to create an interface that is much
+more dynamic and flexible.
+
+** stgit
+
+#+begin_example
+stg mail --version="bpf-next RFC" --cc meup --edit-cover \
+  --to ahern --to bpf --to netdev --cc daniel --cc alexei --cc andrii \
+  move_struct..samples-bpf
+#+end_example
+
+** PATCH: bpf: move struct bpf_devmap_val out of UAPI
+
+The struct bpf_devmap_val doesn't belong in uapi/linux/bpf.h, because this
+is a struct that BPF-progs can define themselves, and can provide different
+sizes to the kernel.
+
+While moving the struct change the union to be a named union, with the name
+"bpf_prog". This makes it easier to identify with BTF in next patch.
+
+
+** PATCH bpf: devmap dynamic map-value storage area based on BTF
+
+The devmap map-value can be read from BPF-prog side, and could be used for a
+storage area per device. This could e.g. contain info on headers that need
+to be added when packet egress this device.
+
+This patchset adds a 'storage' member to struct bpf_devmap_val. More
+importantly the struct bpf_devmap_val is made dynamic via leveraging and
+requiring BTF for struct sizes above 4. The only mandatory struct member is
+'ifindex' with a fixed offset of zero.

--- a/areas/core/BTF_02_proposed_usage.org
+++ b/areas/core/BTF_02_proposed_usage.org
@@ -50,7 +50,7 @@ importantly the struct bpf_devmap_val is made dynamic via leveraging and
 requiring BTF for struct sizes above 4. The only mandatory struct member is
 'ifindex' with a fixed offset of zero.
 
-* Patches attempt-2
+* Working on attempt-2
 
 ** Argue why not a uapi header
 
@@ -113,3 +113,47 @@ $ git whatchanged d39aec79e5923bf984df991ffe51d4a2b7a9e746
  tools/testing/selftests/bpf/progs/test_xdp_devmap_helpers.c
  tools/testing/selftests/bpf/progs/test_xdp_with_devmap_helpers.c
 #+end_example
+
+* Patchset: attempt-2
+
+** PATCH: bpf: devmap dynamic map-value area based on BTF
+
+#+begin_quote
+bpf: devmap dynamic map-value area based on BTF
+
+The recent commit fbee97feed9b ("bpf: Add support to attach bpf program to a
+devmap entry"), introduced ability to attach (and run) a separate XDP
+bpf_prog for each devmap entry. A bpf_prog is added via a file-descriptor,
+thus not using the feature requires using value minus-1. The UAPI is
+extended via tail-extending struct bpf_devmap_val and using map->value_size
+to determine the feature set.
+
+There is a specific problem with dev_map_can_have_prog() check, which is
+called from net/core/dev.c in generic_xdp_install() to refuse usage of
+devmap's from generic-XDP that support these bpf_prog's. The check is size
+based. This means that all newer features will be blocked from being use by
+generic-XDP.
+
+This patch allows userspace to skip handling of 'bpf_prog' on map-inserts.
+The feature can be skipped, via not including the member 'bpf_prog' in the
+map-value struct, which is propagated/described via BTF.
+
+Fixes: fbee97feed9b ("bpf: Add support to attach bpf program to a devmap entry")
+Signed-off-by: Jesper Dangaard Brouer <brouer@redhat.com>
+#+end_quote
+
+Need this patch in, while there is still time before we have to support
+size=8 forever.
+
+Further more, BPF userspace programs using struct bpf_devmap_val will get
+surprised when including it as the tail-extended member will have to be
+initialised to minus-1.
+
+#+begin_src sh
+stg mail --version="bpf-next V1" --cc meup \
+  --to ahern --to bpf --cc netdev --cc daniel --to alexei --cc andrii \
+  --cc lore \
+  bpf-devmap-dynamic-map-value
+#+end_src
+
+

--- a/areas/core/BTF_02_proposed_usage.org
+++ b/areas/core/BTF_02_proposed_usage.org
@@ -5,7 +5,9 @@
 
 
 * Patches attempt-1: Rejected
+[[https://lore.kernel.org/netdev/159076794319.1387573.8722376887638960093.stgit@firesoul/][link]]
 
+#+begin_quote
 bpf: dynamic map-value config layout via BTF
 
 This patchset is based on top of David Ahern's work V3: "bpf: Add support
@@ -20,6 +22,7 @@ binary struct layout that can only be grown in the end of the struct.
 
 With the BTF technology it is possible to create an interface that is much
 more dynamic and flexible.
+#+end_quote
 
 ** stgit
 
@@ -30,17 +33,21 @@ stg mail --version="bpf-next RFC" --cc meup --edit-cover \
 #+end_example
 
 ** PATCH: bpf: move struct bpf_devmap_val out of UAPI
+[[https://lore.kernel.org/netdev/159076798058.1387573.3077178618799401182.stgit@firesoul/][link]]
 
+#+begin_quote
 The struct bpf_devmap_val doesn't belong in uapi/linux/bpf.h, because this
 is a struct that BPF-progs can define themselves, and can provide different
 sizes to the kernel.
 
 While moving the struct change the union to be a named union, with the name
 "bpf_prog". This makes it easier to identify with BTF in next patch.
-
+#+end_quote
 
 ** PATCH bpf: devmap dynamic map-value storage area based on BTF
+[[https://lore.kernel.org/netdev/159076798566.1387573.8417040652693679408.stgit@firesoul/][link]]
 
+#+begin_quote
 The devmap map-value can be read from BPF-prog side, and could be used for a
 storage area per device. This could e.g. contain info on headers that need
 to be added when packet egress this device.
@@ -49,6 +56,10 @@ This patchset adds a 'storage' member to struct bpf_devmap_val. More
 importantly the struct bpf_devmap_val is made dynamic via leveraging and
 requiring BTF for struct sizes above 4. The only mandatory struct member is
 'ifindex' with a fixed offset of zero.
+#+end_quote
+
+** PATCH: samples/bpf: change xdp_fwd to use new BTF config interface
+[[https://lore.kernel.org/netdev/159076799073.1387573.15478442988219832285.stgit@firesoul/][link]]
 
 * Working on attempt-2
 

--- a/areas/core/BTF_02_proposed_usage.org
+++ b/areas/core/BTF_02_proposed_usage.org
@@ -180,10 +180,10 @@ stg mail --version="bpf-next V1" --cc meup \
   bpf-devmap-dynamic-map-value
 #+end_src
 
-
 * Patchset: attempt-3 - no FD zero
 
 *New direction*: Simply avoid FD zero is used by BPF
+- This drops using BTF
 
 Above attempts tried to solve the kABI issue in a too advanced fashion (via
 making it dynamic via BTF). The *real practical issue* is that it is hard to
@@ -231,7 +231,9 @@ Message-ID: <159163498340.1967373.5048584263152085317.stgit@firesoul>
 - [[https://lore.kernel.org/bpf/159163498340.1967373.5048584263152085317.stgit@firesoul/][link]]
 
 ** Patch-1: bpf: syscall to start at file-descriptor 1
+[[https://lore.kernel.org/netdev/159163507753.1967373.62249862728421448.stgit@firesoul/][link]]
 
+#+begin_quote
 This patch change BPF syscall to avoid returning file descriptor value zero.
 
 As mentioned in cover letter, it is very impractical when extending kABI
@@ -244,8 +246,10 @@ exception of getting unused FD starting from 1. The kernel already supports
 starting from a specific FD value, as this is used by f_dupfd(). It seems
 simpler to replicate part of anon_inode_getfd() code and use this start from
 offset feature, instead of using f_dupfd() handling afterwards.
+#+end_quote
 
 ** Patch-2:
+[[https://lore.kernel.org/bpf/159163508261.1967373.10375683361894729822.stgit@firesoul/][link]]
 
 #+begin_quote
 bpf: devmap adjust uapi for attach bpf program
@@ -271,6 +275,7 @@ Fixes: fbee97feed9b ("bpf: Add support to attach bpf program to a devmap entry")
 #+end_quote
 
 ** Patch-3:
+[[https://lore.kernel.org/bpf/159163508769.1967373.9026895070748918567.stgit@firesoul/][link]]
 
 #+begin_quote
 bpf: selftests and tools use struct bpf_devmap_val from uapi
@@ -278,3 +283,82 @@ bpf: selftests and tools use struct bpf_devmap_val from uapi
 Sync tools uapi bpf.h header file and selftests that use struct
 bpf_devmap_val.
 #+end_quote
+
+
+* Patchset: attempt-4
+
+Alexei didn't like patch1, but wanted to patch 2+3.
+- [[https://lore.kernel.org/bpf/20200609013410.5ktyuzlqu5xpbp4a@ast-mbp.dhcp.thefacebook.com/][link]]
+- Message-ID: <20200609013410.5ktyuzlqu5xpbp4a@ast-mbp.dhcp.thefacebook.com>
+
+I disagree, and think patch-1 is a pre-requisite, but it is more important
+to fix the UAPI (ABI) issue of minus-1. So, I can live with the unlikely
+case of getting FD=0 back.
+
+** cover-letter
+Message-ID: <159170947966.2102545.14401752480810420709.stgit@firesoul
+- [[https://lore.kernel.org/bpf/159170947966.2102545.14401752480810420709.stgit@firesoul/][link]]
+
+#+begin_quote
+bpf: adjust uapi for devmap prior to kernel release
+
+For special type maps (e.g. devmap and cpumap) the map-value data-layout is
+a configuration interface. This is uapi that can only be tail extended.
+Thus, new members (and thus features) can only be added to the end of this
+structure, and the kernel uses the map->value_size from userspace to
+determine feature set 'version'.
+
+For this kind of uapi to be extensible and backward compatible, is it common
+that new members/fields (that represent a new feature) in the struct are
+initialized as zero, which indicate that the feature isn't used. This makes
+it possible to write userspace applications that are unaware of new kernel
+features, but just include latest uapi headers, zero-init struct and
+populate features it knows about.
+
+The recent extension of devmap with a bpf_prog.fd requires end-user to
+supply the file-descriptor value minus-1 to communicate that the features
+isn't used. This isn't compatible with the described kABI extension model.
+
+V2: Drop patch-1 that changed BPF-syscall to start at file-descriptor 1
+#+end_quote
+
+*** stg mail
+
+#+begin_src sh
+stg mail --version="bpf V2" --cc meup --edit-cover \
+ --in-reply-to="20200609013410.5ktyuzlqu5xpbp4a@ast-mbp.dhcp.thefacebook.com" \
+ --to ahern --to bpf --cc netdev --cc daniel --to alexei \
+ --cc andrii --cc lore \
+ bpf-devmap-adjust-uapi-for..bpf-selftests-and-tools-use
+#+end_src
+
+** patch:
+
+#+begin_quote
+bpf: devmap adjust uapi for attach bpf program
+
+V2:
+- Defer changing BPF-syscall to start at file-descriptor 1
+- Use {} to zero initialise struct.
+
+The recent commit fbee97feed9b ("bpf: Add support to attach bpf program to a
+devmap entry"), introduced ability to attach (and run) a separate XDP
+bpf_prog for each devmap entry. A bpf_prog is added via a file-descriptor.
+As zero were a valid FD, not using the feature requires using value minus-1.
+The UAPI is extended via tail-extending struct bpf_devmap_val and using
+map->value_size to determine the feature set.
+
+This will break older userspace applications not using the bpf_prog feature.
+Consider an old userspace app that is compiled against newer kernel
+uapi/bpf.h, it will not know that it need to initialise the member
+bpf_prog.fd to minus-1. Thus, users will be forced to update source code to
+get program running on newer kernels.
+
+This patch remove the minus-1 checks, and have zero mean feature isn't used.
+
+Followup patches either for kernel or libbpf should handle and avoid
+returning file-descriptor zero in the first place.
+
+Fixes: fbee97feed9b ("bpf: Add support to attach bpf program to a devmap entry")
+#+end_quote
+


### PR DESCRIPTION
Keeping notes while trying to understand how we as kernel developers can use BTF from the kernel-side to validate and dynamically extend data provided from userspace.

Trying to share as a GitHub pull-request, not sure it makes sense, but I'm trying to find a way to share it with @LorenzoBianconi and @dsahern 