### PR TITLE
Update tool to evaluate kernel cgroup rstat locking time

### DIFF
--- a/areas/latency/cgroup_rstat_latency_steroids.bt
+++ b/areas/latency/cgroup_rstat_latency_steroids.bt
@@ -1,0 +1,128 @@
+#!/usr/local/bin/bpftrace
+/* SPDX-License-Identifier: GPL-2.0+
+ *
+ * Script for evaluation the latency effect cgroup rstat (recursive stats).
+ *
+ * Production experience with softirq_net_latency.bt indicate that reading
+ * cgroup rstat (files under subdirs in /sys/fs/cgroup/) is *one* of the
+ * factors that can disrupt softirq processing.
+ *
+ * This script zoom into cgroup rstat function to evaluate kernel
+ * improvements in this area.
+ *
+ * 03-Apr-2024	Jesper Dangaard Brouer	Created this
+ */
+BEGIN
+{
+	/* Cmdline arg#1: runtime threshold input in usec */
+	@threshold1_usecs = $1 ? $1: 10000;
+	@threshold1_ns = @threshold1_usecs * 1000;
+
+	/* Cmdline arg#2: wait time threshold input in usec */
+	@threshold2_usecs = $2 ? $2: 1000;
+	@threshold2_ns = @threshold2_usecs * 1000;
+
+	printf("Tracing latency caused by cgroup rstat\n");
+	printf(" - Will report on runtime above %d usecs (= %d ms)\n",
+	       @threshold1_usecs, @threshold1_usecs / 1000);
+	printf(" - Will report on WAIT time above %d usecs (= %d ms)\n",
+	       @threshold2_usecs, @threshold2_usecs / 1000);
+	printf("... Hit Ctrl-C to end.\n");
+}
+
+
+kfunc:cgroup_rstat_flush,
+kfunc:cgroup_rstat_flush_hold
+{
+	/* Concurrency issue here? */
+	if (@flush_start[tid]) {
+		printf("Concurrency issue: tid[%d] comm[%s] %s\n",
+		       tid, comm, probe);
+	}
+
+	@flush_start[tid] = nsecs;
+}
+
+/* The _irqsafe variant exists on older kernels (e.g kernel 6.1)
+ */
+/*
+kfunc:cgroup_rstat_flush_irqsafe
+{
+	@flush_start[tid] = nsecs;
+}
+*/
+
+/* Idea: Can we calculate/deduce the time spend waiting for lock?
+ *
+ * Entering cgroup_rstat_flush_locked() means we are holding the
+ * cgroup_rstat_lock. Calculating time in this function and subtracting it from
+ * cgroup_rstat_flush runtime, should give us time waiting for lock. The resched
+ * in cgroup_rstat_flush_locked() might screw this number.
+ */
+kfunc:cgroup_rstat_flush_locked
+{
+	/* Concurrency issue here? */
+	if (@flush_locked_start[tid]) {
+		printf("Concurrency issue: tid[%d] comm[%s] %s\n",
+		       tid, comm, probe);
+	}
+
+	if (@flush_start[tid] > 0) {
+		@flush_locked_start[tid] = nsecs;
+	}
+}
+
+kretprobe:cgroup_rstat_flush,
+kretprobe:cgroup_rstat_flush_irqsafe,
+kretprobe:cgroup_rstat_flush_release
+{
+	if (@flush_start[tid] > 0) {
+		$now = nsecs;
+		$runtime = $now - @flush_start[tid];
+		$locked_time = $now - @flush_locked_start[tid];
+		$wait_time = $runtime - $locked_time;
+
+		@runtime_hist_ns = hist($runtime);
+		@wait_time_hist_ns = hist($wait_time);
+
+		/* Report on events over threshold.
+		 *
+		 * Likely a spin_lock congestion on cgroup_rstat_lock.
+		 *
+		 * This runtime can include "too much" as a resched point in
+		 * cgroup_rstat_flush_locked() exists, but the calling code will
+		 * experience this delay.
+		 */
+		if ($runtime >= @threshold1_ns || $wait_time >= @threshold2_ns ) {
+			@stack[tid, comm] = kstack;
+			time("%H:%M:%S ");
+			printf("High runtime: %d usec (%d ms) wait: %d usec (%d ms) on CPU:%d comm:%s func:%s\n",
+			       $runtime / 1000, $runtime / 1000000,
+			       $wait_time / 1000, $wait_time / 1000000,
+			       cpu, comm, func);
+		}
+	}
+	delete(@flush_start[tid]);
+	delete(@flush_locked_start[tid]);
+}
+
+
+
+interval:s:10
+{
+	time("%H:%M:%S ");
+	printf(" time elapsed: %d sec\n", elapsed / 1000000000);
+	print(@runtime_hist_ns);
+	print(@wait_time_hist_ns);
+	//clear(@runtime_hist_ns);
+}
+
+END
+{	/* Default bpftrace will print all remaining maps at END */
+	clear(@threshold1_usecs);
+	clear(@threshold1_ns);
+	clear(@threshold2_usecs);
+	clear(@threshold2_ns);
+	time("%H:%M:%S ");
+	printf("END time elapsed: %d sec\n", elapsed / 1000000000);
+}

--- a/areas/latency/cgroup_rstat_latency_steroids.bt
+++ b/areas/latency/cgroup_rstat_latency_steroids.bt
@@ -44,15 +44,19 @@ BEGIN
  * this allows us to measure locks critical section (where it blocks IRQs and
  * BH/softirq).
  *
- * Decoding the offsets
+ * Decoding the offsets requires access to the binary build with debuginfo.
  *
  * For kernel build: 6.6.22-cloudflare-2024.3.15
  *  cgroup_rstat_flush_locked+0x235 = unlock
  *  cgroup_rstat_flush_locked+0x24c = lock again
  *
+ * For kernel build 6.6.21-cloudflare-2024.3.8 we see:
+ *  cgroup_rstat_flush_locked+0x2aa = unlock
+ *  cgroup_rstat_flush_locked+0x2c1 = lock again
+ *
  */
-//kprobe:cgroup_rstat_flush_locked+0x235 { /* unlock */ }
-//kprobe:cgroup_rstat_flush_locked+0x24c { /*lock again */ }
+//kprobe:cgroup_rstat_flush_locked+0x235 {/* unlock */}
+//kprobe:cgroup_rstat_flush_locked+0x24c {/* lock again */}
 
 /* Start flush operation */
 kfunc:cgroup_rstat_flush,
@@ -98,6 +102,7 @@ kfunc:cgroup_rstat_flush_locked
 }
 
 kprobe:cgroup_rstat_flush_locked+0x24c // lock again (6.6.22-cloudflare-2024.3.15)
+//kprobe:cgroup_rstat_flush_locked+0x2c1 // lock again (6.6.21-cloudflare-2024.3.8)
 {
 	if (@flush_start[tid] > 0) {
 		$now = nsecs;
@@ -110,6 +115,7 @@ kprobe:cgroup_rstat_flush_locked+0x24c // lock again (6.6.22-cloudflare-2024.3.1
 kretprobe:cgroup_rstat_flush,
 kretprobe:cgroup_rstat_flush_release,
 kprobe:cgroup_rstat_flush_locked+0x235 /* unlock (6.6.22-cloudflare-2024.3.15) */
+//kprobe:cgroup_rstat_flush_locked+0x2aa /* unlock (6.6.21-cloudflare-2024.3.8) */
 {
 	if (@flush_start[tid] > 0) {
 		$now = nsecs;

--- a/areas/latency/cgroup_rstat_latency_steroids.bt
+++ b/areas/latency/cgroup_rstat_latency_steroids.bt
@@ -123,7 +123,7 @@ kprobe:cgroup_rstat_flush_locked+0x235 /* unlock (6.6.22-cloudflare-2024.3.15) *
 		$locked_time = $now - @flush_locked_start[tid];
 		$wait_time = $runtime - $locked_time;
 
-		@runtime_hist_ns = hist($runtime);
+		@lock_time_hist_ns = hist($runtime);
 		@wait_time_hist_ns = hist($wait_time);
 
 		/* Report on events over threshold.
@@ -153,9 +153,8 @@ interval:s:10
 {
 	time("%H:%M:%S ");
 	printf(" time elapsed: %d sec\n", elapsed / 1000000000);
-	print(@runtime_hist_ns);
+	print(@lock_time_hist_ns);
 	print(@wait_time_hist_ns);
-	//clear(@runtime_hist_ns);
 }
 
 END

--- a/areas/latency/cgroup_rstat_latency_steroids.bt
+++ b/areas/latency/cgroup_rstat_latency_steroids.bt
@@ -11,6 +11,9 @@
  * improvements in this area.
  *
  * 03-Apr-2024	Jesper Dangaard Brouer	Created this
+ * 05-Apr-2024	Jesper Dangaard Brouer	Steroids: needs adaption to binary build
+ *
+ *
  */
 BEGIN
 {
@@ -30,7 +33,28 @@ BEGIN
 	printf("... Hit Ctrl-C to end.\n");
 }
 
+/* Steroids: You don't want to take this pill
+ *
+ * It is possible to use kprobes attached to the middle of a kernel function. as
+ * described in:
+ * https://blog.tohojo.dk/2023/04/netfilter-packet-drop-attribution-using-bpf.html
+ *
+ * I want to know if (and when) `cgroup_rstat_flush_locked()` a release of
+ * cgroup_rstat_lock in side the loop (see comment "play nice and yield"). As
+ * this allows us to measure locks critical section (where it blocks IRQs and
+ * BH/softirq).
+ *
+ * Decoding the offsets
+ *
+ * For kernel build: 6.6.22-cloudflare-2024.3.15
+ *  cgroup_rstat_flush_locked+0x235 = unlock
+ *  cgroup_rstat_flush_locked+0x24c = lock again
+ *
+ */
+//kprobe:cgroup_rstat_flush_locked+0x235 { /* unlock */ }
+//kprobe:cgroup_rstat_flush_locked+0x24c { /*lock again */ }
 
+/* Start flush operation */
 kfunc:cgroup_rstat_flush,
 kfunc:cgroup_rstat_flush_hold
 {
@@ -56,8 +80,9 @@ kfunc:cgroup_rstat_flush_irqsafe
  *
  * Entering cgroup_rstat_flush_locked() means we are holding the
  * cgroup_rstat_lock. Calculating time in this function and subtracting it from
- * cgroup_rstat_flush runtime, should give us time waiting for lock. The resched
- * in cgroup_rstat_flush_locked() might screw this number.
+ * cgroup_rstat_flush runtime, should give us time waiting for lock.
+ *
+ * The resched in cgroup_rstat_flush_locked() is captured via offset kprobes
  */
 kfunc:cgroup_rstat_flush_locked
 {
@@ -72,9 +97,19 @@ kfunc:cgroup_rstat_flush_locked
 	}
 }
 
+kprobe:cgroup_rstat_flush_locked+0x24c // lock again (6.6.22-cloudflare-2024.3.15)
+{
+	if (@flush_start[tid] > 0) {
+		$now = nsecs;
+		@flush_locked_start[tid] = $now;
+		@flush_start[tid] = $now; // Reset "start" time
+	}
+}
+
+// kretprobe:cgroup_rstat_flush_irqsafe,
 kretprobe:cgroup_rstat_flush,
-kretprobe:cgroup_rstat_flush_irqsafe,
-kretprobe:cgroup_rstat_flush_release
+kretprobe:cgroup_rstat_flush_release,
+kprobe:cgroup_rstat_flush_locked+0x235 /* unlock (6.6.22-cloudflare-2024.3.15) */
 {
 	if (@flush_start[tid] > 0) {
 		$now = nsecs;
@@ -96,10 +131,10 @@ kretprobe:cgroup_rstat_flush_release
 		if ($runtime >= @threshold1_ns || $wait_time >= @threshold2_ns ) {
 			@stack[tid, comm] = kstack;
 			time("%H:%M:%S ");
-			printf("High runtime: %d usec (%d ms) wait: %d usec (%d ms) on CPU:%d comm:%s func:%s\n",
+			printf("High lock_time: %d usec (%d ms) wait: %d usec (%d ms) on CPU:%d comm:%s func:%s probe:%s\n",
 			       $runtime / 1000, $runtime / 1000000,
 			       $wait_time / 1000, $wait_time / 1000000,
-			       cpu, comm, func);
+			       cpu, comm, func, probe);
 		}
 	}
 	delete(@flush_start[tid]);


### PR DESCRIPTION
Adding an "on-steroids" version of script `cgroup_rstat_latency_steroids.bt`

- called `cgroup_rstat_latency_steroids.bt`

Keeping this separate given this is **script is not maintainable**

- as it contains kprobes with offsets to match specific kernel builds

The script takes the `unlock`/`lock`-again reschedule mechanism into account

- being do in [cgroup_rstat_flush_locked](https://elixir.bootlin.com/linux/v6.6.25/source/kernel/cgroup/rstat.c#L212) loop code

Thus, allow us to measure the real *lock time* cost

- that due to spin_lock  `irq` variants can block IRQs and BH/softirq for this period of time (although only on the current running CPU)


