### PR TITLE
xdp_mem_track01: adjust for kernel v5.5 change

### DIFF
--- a/areas/mem/bpftrace/xdp_mem_track01.bt
+++ b/areas/mem/bpftrace/xdp_mem_track01.bt
@@ -2,13 +2,13 @@
 /*
  * xdp_mem_track01 - Catch when XDP mem_model unreg see inflight packets/pages
  *
- * In certain cases when unregistring a page_pool allocator via the
- * kernels xdp_rxq_info_unreg() / xdp_rxq_info_unreg_mem_model() call,
- * then there can still be inflight packets/pages. The purpose is to
- * catch these cases, to make sure this code path is activated.
+ * Since kernel v5.5 the page_pool is responsible for its own delayed
+ *  destruction instead of relying on XDP, see commit
+ *  c3f812cea0d7 ("page_pool: do not release pool until inflight == 0.")
  *
+ * Thus,
  * NIC driver developers converting their driver to use page_pool, should
- * use this script to verify, they don't leak pages.
+ * use other scripts to verify, they don't leak pages.
  */
 
 BEGIN {
@@ -38,40 +38,25 @@ tracepoint:xdp:mem_disconnect {
 	$type      = args->mem_type;
 	$type_str  = @types[$type];
 
-	$cnt = args->disconnect_cnt;
-	$safe_to_remove = args->safe_to_remove;
-
 	time(); /* Used as event marker */
 
 	$time_ms = 0;
 	if (@active_mem_ids[$id]) {
 		$time_ms = (nsecs - @active_mem_ids[$id]) / 1000000;
 	}
+	delete(@active_mem_ids[$id]);
 
-	if ($safe_to_remove == 0) {
-		printf("%s: type:%s mem.id=%d NOT-safe_to_remove:%d (*HIT*)\n",
-		       probe, $type_str, $id, $safe_to_remove);
-		/* Track here as xdp:mem_connect didn't see connect */
-		if ($time_ms == 0) {
-			@active_mem_ids[$id] = nsecs;
-		}
-		/* Print mem IDs that hit not-safe-to-remove */
-		@test_case_hit[$id, $time_ms] = $cnt;
+	if ($time_ms == 0) {
+		/* No time means xdp:mem_connect didn't see connect */
+		printf("%s: type:%s mem.id:%d 0x%lX (didn't see xdp:mem_connect)\n",
+		       probe, $type_str, $id,  $page_pool);
 	} else {
-		delete(@active_mem_ids[$id]);
+		printf("%s: type:%s mem.id:%d 0x%lX (lived %d ms)\n",
+		       probe, $type_str, $id,  $page_pool, $time_ms);
 	}
-
-	if ($cnt > 1) {
-		printf("%s: type:%s mem.id=%d re-sched(%d) safe_to_remove:%d\n",
-		       probe, $type_str, $id, $cnt, $safe_to_remove);
-	}
-
-	printf("%s: type:%s mem.id:%d 0x%lX safe_to_remove:%d (lived %d ms)\n",
-	       probe, $type_str, $id,  $page_pool, $safe_to_remove, $time_ms);
 }
 
 END {
 	/* Default bpftrace will print all remaining maps at END */
 	clear(@types); /* Avoid printing @types table */
 }
-


### PR DESCRIPTION
The bpftrace script xdp_mem_track01.bt gotten less useful as since kernel v5.5 as the page_pool is responsible for its own delayed destruction instead of relying on XDP.

Make the script compile/run again. As tracepoint:xdp:mem_disconnect lost args disconnect_cnt and safe_to_remove then simplify the script to avoid using these args.