### PR TITLE
Minor fixes to areas/latency/cgroup_rstat_tracepoint.bt

### DIFF
--- a/areas/latency/cgroup_rstat_tracepoint.bt
+++ b/areas/latency/cgroup_rstat_tracepoint.bt
@@ -63,7 +63,7 @@ tracepoint:cgroup:cgroup_rstat_locked
 		@wait_ns=hist($wait_time);
 		delete(@wait_start[tid]);
 	} else {
-		$wait = 0;
+		$wait_time = 0;
 	}
 
 	/* WARNING: Using @xxx++ is an expensive atomic operation.
@@ -175,7 +175,7 @@ tracepoint:cgroup:cgroup_rstat_cpu_locked
 		@wait_per_cpu_ns=hist($wait_time);
 		delete(@wait_cpu_start[tid]);
 	} else {
-		$wait = 0;
+		$wait_time = 0;
 	}
 
 	@lock_cpu_cnt = count();

--- a/areas/latency/cgroup_rstat_tracepoint.bt
+++ b/areas/latency/cgroup_rstat_tracepoint.bt
@@ -66,7 +66,7 @@ tracepoint:cgroup:cgroup_rstat_locked
 		$wait_time = 0;
 	}
 
-	/* WARNING: Using @xxx++ is an expensive atomic operation.
+	/* WARNING: Using @xxx++ is slow (non-atomic) operation dirtying cache-lines
 	 *  Recommend using @xxx = count()
 	 *  Not doing it here as "count" type cannot be used in printf
 	*/


### PR DESCRIPTION
The bpftrace increment operator is both slow and contain data races.
Fix comment, where I thought slowness was due to it being an atomic operation.

Upstream bpftrace issues are in progress for improving performance and reduce data races:

- https://github.com/bpftrace/bpftrace/issues/3175
- https://github.com/bpftrace/bpftrace/pull/3179
