### PR TITLE
Doc: Adding veth backpressure to reduce TX drops

### DIFF
--- a/areas/core/veth05_backpressure.org
+++ b/areas/core/veth05_backpressure.org
@@ -8,6 +8,14 @@ into the qdisc layer.
 We observed a production problem, and we have constructed a reproducer, and are
 now working on a patch for veth.
 
+* Table of Contents                                                     :toc:
+- [[#what-is-veth][What is veth]]
+- [[#issue][Issue]]
+  - [[#packet-flow-leading-to-tx-drops][Packet flow leading to TX drops]]
+- [[#reproducer][Reproducer]]
+- [[#patch-descriptions][Patch descriptions]]
+  - [[#patch-1-veth-qdisc-backpressure][Patch-1: veth qdisc backpressure]]
+
 * What is veth
 
 The Linux kernels virtual ethernet driver (called =veth=) is primary used for
@@ -16,11 +24,33 @@ building block for containers.
 
 * Issue
 
-We are observing packet drops between veth pairs in production. This issue is
+We are observing packet TX drops between veth pairs in production. This issue is
 occurring within the veth driver function =veth_xmit()=, specifically when
 operating in NAPI mode (enabled via GRO or XDP mode) and using threaded-NAPI.
 The drops occur due to the internal =ptr_ring= buffer (=xdp_ring=) becoming
 full, leading to packet loss.
+
+** Packet flow leading to TX drops
+
+Packets are routed by netstack with a destination "into" a veth device, which
+gets processed by the veth driver via =ndo_start_xmit=, which calls
+veth_xmit().
+
+Then veth_xmit() invokes veth_forward_skb(), which, due to GRO/XDP mode, results
+in calling veth_xdp_rx().
+
+Inside veth_xdp_rx() SKB packets are enqueued into a ptr_ring FIFO queue (called
+xdp_ring) using ptr_ring_produce().
+
+The drop observation is that ptr_ring gets full and packets are dropped.
+
+The veth peer is responsible for consuming packets via ptr_ring_consume() in
+veth_xdp_rcv(), which runs as part of the veth_poll() NAPI callback.
+
+The consumer function runs in softirq context but appears to be delayed or
+disturbed, leading to bursts of packet drops. The consumer is often slower than
+the producer, due to many nftables rules (that can vary based on customer
+configuration).
 
 * Reproducer
 

--- a/areas/core/veth05_backpressure.org
+++ b/areas/core/veth05_backpressure.org
@@ -22,3 +22,7 @@ operating in NAPI mode (enabled via GRO or XDP mode) and using threaded-NAPI.
 The drops occur due to the internal =ptr_ring= buffer (=xdp_ring=) becoming
 full, leading to packet loss.
 
+* Reproducer
+
+Reproducer script available here: [[file:veth_setup01_NAPI_TX_drops.sh]]
+

--- a/areas/core/veth05_backpressure.org
+++ b/areas/core/veth05_backpressure.org
@@ -60,6 +60,9 @@ Reproducer script available here: [[file:veth_setup01_NAPI_TX_drops.sh]]
 
 ** Patch-1: veth qdisc backpressure
 
+Posted upstream:
+ - RFC: https://lore.kernel.org/all/174377814192.3376479.16481605648460889310.stgit@firesoul/
+
 #+begin_quote
 veth: apply qdisc backpressure on full ptr_ring to reduce TX drops
 
@@ -107,5 +110,4 @@ like veth.
 Reported-by: Yan Zhai <yan@cloudflare.com>
 Signed-off-by: Jesper Dangaard Brouer <hawk@kernel.org>
 #+end_quote
-
 

--- a/areas/core/veth05_backpressure.org
+++ b/areas/core/veth05_backpressure.org
@@ -26,3 +26,56 @@ full, leading to packet loss.
 
 Reproducer script available here: [[file:veth_setup01_NAPI_TX_drops.sh]]
 
+* Patch descriptions
+
+** Patch-1: veth qdisc backpressure
+
+#+begin_quote
+veth: apply qdisc backpressure on full ptr_ring to reduce TX drops
+
+In production, we're seeing TX drops on veth devices when the ptr_ring
+fills up. This can occur when NAPI mode is enabled, though it's
+relatively rare. However, with threaded NAPI - which we use in
+production - the drops become significantly more frequent.
+
+The underlying issue is that with threaded NAPI, the consumer often runs
+on a different CPU than the producer. This increases the likelihood of
+the ring filling up before the consumer gets scheduled, especially under
+load, leading to drops in veth_xmit() (ndo_start_xmit()).
+
+This patch introduces backpressure by returning NETDEV_TX_BUSY when the
+ring is full, signaling the qdisc layer to requeue the packet. The txq
+(netdev queue) is stopped in this condition and restarted once
+veth_poll() drains entries from the ring, ensuring coordination between
+NAPI and qdisc.
+
+Backpressure is only enabled when a qdisc is attached. Without a qdisc,
+the driver retains its original behavior - dropping packets immediately
+when the ring is full. This avoids unexpected behavior changes in setups
+without a configured qdisc.
+
+With a qdisc in place (e.g. fq, sfq) this allows Active Queue Management
+(AQM) to fairly schedule packets across flows and reduce collateral
+damage from elephant flows.
+
+A known limitation of this approach is that the full ring sits in front
+of the qdisc layer, effectively forming a FIFO buffer that introduces
+base latency. While AQM still improves fairness and mitigates flow
+dominance, the latency impact is measurable.
+
+In hardware drivers, this issue is typically addressed using BQL (Byte
+Queue Limits), which tracks in-flight bytes needed based on physical link
+rate. However, for virtual drivers like veth, there is no fixed bandwidth
+constraint - the bottleneck is CPU availability and the scheduler's ability
+to run the NAPI thread. It is unclear how effective BQL would be in this
+context.
+
+This patch serves as a first step toward addressing TX drops. Future work
+may explore adapting a BQL-like mechanism to better suit virtual devices
+like veth.
+
+Reported-by: Yan Zhai <yan@cloudflare.com>
+Signed-off-by: Jesper Dangaard Brouer <hawk@kernel.org>
+#+end_quote
+
+

--- a/areas/core/veth05_backpressure.org
+++ b/areas/core/veth05_backpressure.org
@@ -1,0 +1,24 @@
+#+Title: veth lacking back-pressure leading to drops
+
+The target audience of this document is other upstream kernel developers.
+
+These are my notes when developing a patch to =veth= that adds back-pressure
+into the qdisc layer.
+
+We observed a production problem, and we have constructed a reproducer, and are
+now working on a patch for veth.
+
+* What is veth
+
+The Linux kernels virtual ethernet driver (called =veth=) is primary used for
+providing networking between network namespaces (netns), which is a fundamental
+building block for containers.
+
+* Issue
+
+We are observing packet drops between veth pairs in production. This issue is
+occurring within the veth driver function =veth_xmit()=, specifically when
+operating in NAPI mode (enabled via GRO or XDP mode) and using threaded-NAPI.
+The drops occur due to the internal =ptr_ring= buffer (=xdp_ring=) becoming
+full, leading to packet loss.
+

--- a/areas/core/veth_setup01_NAPI_TX_drops.sh
+++ b/areas/core/veth_setup01_NAPI_TX_drops.sh
@@ -1,0 +1,109 @@
+#!/bin/bash -x
+#
+# Reproducer for veth TX drops in threaded NAPI mode
+#
+# Script adapted from Yan Zhai
+#
+function root_check_run_with_sudo() {
+    # Trick so, program can be run as normal user, will just use "sudo"
+    #  call as root_check_run_as_sudo "$@"
+    if [ "$EUID" -ne 0 ]; then
+        if [ -x $0 ]; then # Directly executable use sudo
+            echo "Not root, running with sudo"
+            sudo "$0" "$@"
+            exit $?
+        fi
+        err 4 "cannot perform sudo run of $0"
+    fi
+}
+root_check_run_with_sudo "$@"
+
+# Cleanup any old netns
+ip netns delete n1
+ip netns delete n2
+ip netns delete n3
+
+# Commands from Yan
+# -----------------
+# setting up three ns and create a bottleneck veth pair "v23-v32"
+ip netns add n1
+ip netns add n2
+ip netns add n3
+
+for n in n1 n2 n3; do
+        ip -n $n link set lo up
+done
+
+# To easier show the problem
+#  - limit veth to single TX + RX queues
+ip -n n1 link add v12 numtxqueues 1 numrxqueues 1 type veth peer name v21 numtxqueues 1 numrxqueues 1 netns n2
+ip -n n3 link add v32 numtxqueues 1 numrxqueues 1 type veth peer name v23 numtxqueues 1 numrxqueues 1 netns n2
+
+ip -n n1 link set v12 up
+ip -n n3 link set v32 up
+ip -n n2 link set v21 up
+ip -n n2 link set v23 up
+
+ip -n n1 addr add dev lo 1.1.1.1/32
+ip -n n2 addr add dev lo 2.2.2.2/32
+ip -n n3 addr add dev lo 3.3.3.3/32
+ip netns exec n2 sysctl -w net.ipv4.ip_forward=1
+
+ip -n n1 addr add dev v12 192.168.1.2/31
+ip -n n2 addr add dev v21 192.168.1.3/31
+
+ip -n n2 addr add dev v23 192.168.2.2/31
+ip -n n3 addr add dev v32 192.168.2.3/31
+
+ip -n n1 route add default via 192.168.1.3 src 1.1.1.1
+ip -n n2 route add 3.3.3.3 via 192.168.2.3 src 2.2.2.2
+
+ip -n n2 route add 1.1.1.1 via 192.168.1.2 src 2.2.2.2
+ip -n n3 route add default via 192.168.2.2 src 3.3.3.3
+
+# Setting GRO on will force using NAPI rather than backlog
+#  - hint we don't need to load XDP-prog
+ip netns exec n3 ethtool -K v32 gro on
+ip netns exec n2 ethtool -K v23 tso off # if testing with UDP
+# set up threaded NAPI
+ip netns exec n3 bash -c "echo 1 > /sys/class/net/v32/threaded"
+
+# Making NAPI thread slower via many iptables rules
+ip netns exec n3 bash -c '
+ for n in `seq 1 1000`; do
+  iptables -I INPUT -d 3.3.3.3;
+ done
+'
+
+#### Manual test commands
+## first run UDP server
+# ip netns exec n3 iperf -i 1 -s -4 -l 1450 -u
+
+## and client UDP test
+# ip netns exec n1 iperf -i 1 -c 3.3.3.3 -u -l 1450 -b 2g -P 10
+
+## TCP test
+# ip netns exec n3 iperf -i 1 -s -4 -l 1450
+# ip netns exec n1 iperf -i 1 -c 3.3.3.3
+
+## Ping latency observations
+# ip netns exec n1 ping 3.3.3.3
+# ip netns exec n1 ping -i 0.005 -c 100 3.3.3.3 -q
+
+## Enter
+# ip netns exec n1 bash
+
+### TC qdisc setup
+## Add a qdisc to v23 (in n2)
+##
+# ip netns exec n2 tc qdisc replace dev v23 root sfq
+# ip netns exec n2 tc qdisc replace dev v23 root fq_codel
+# ip netns exec n2 tc qdisc replace dev v23 root fq
+# ip netns exec n2 tc qdisc replace dev v23 root pfifo
+#
+## Clear existing setup
+# ip netns exec n2 tc qdisc del dev v23 root
+#
+## Monitor
+# ip netns exec n2 watch -d ifconfig  # See TX dropped counter
+# ip netns exec n2 watch -d tc -s qdisc


### PR DESCRIPTION
These are my notes when developing a patch to `veth` that adds back-pressure into the qdisc layer.

1. We observed a production problem, and
2. we have constructed a reproducer, and
3. are now working on a patch for veth.